### PR TITLE
feature/#9 Comment Entity 생성

### DIFF
--- a/aics-core/aics-domain/src/main/java/kgu/developers/core/domain/comment/Comment.java
+++ b/aics-core/aics-domain/src/main/java/kgu/developers/core/domain/comment/Comment.java
@@ -1,0 +1,50 @@
+package kgu.developers.core.domain.comment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kgu.developers.core.common.domain.BaseTimeEntity;
+import kgu.developers.core.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Comment extends BaseTimeEntity {
+	@Id
+	@Column(name = "comment_id")
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String content;
+
+	/*
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "post_id", nullable = false)
+	private Post post;
+	*/
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "author_id", nullable = false)
+	private User author;
+
+	public static Comment create(String content, User author) {
+		return Comment.builder()
+			.content(content)
+			.author(author)
+			.build();
+	}
+
+}

--- a/aics-core/aics-domain/src/main/java/kgu/developers/core/domain/comment/Comment.java
+++ b/aics-core/aics-domain/src/main/java/kgu/developers/core/domain/comment/Comment.java
@@ -1,9 +1,12 @@
 package kgu.developers.core.domain.comment;
 
+import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.GenerationType.*;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import kgu.developers.core.common.domain.BaseTimeEntity;
@@ -12,9 +15,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import static jakarta.persistence.FetchType.LAZY;
-import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
 @Getter
@@ -30,7 +30,7 @@ public class Comment extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String content;
 
-	/*
+	/* todo : 주석 해제
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "post_id", nullable = false)
 	private Post post;
@@ -40,10 +40,9 @@ public class Comment extends BaseTimeEntity {
 	@JoinColumn(name = "author_id", nullable = false)
 	private User author;
 
-	public static Comment create(String content, User author) {
-		return Comment.builder()
-			.content(content)
-			.author(author)
+	public static Comment create(String content, User author/*todo: 주석 해제 ,Post post*/) {
+		return Comment.builder().content(content).author(author)
+			//todo: 주석해제 .post(post)
 			.build();
 	}
 

--- a/aics-core/aics-domain/src/main/java/kgu/developers/core/domain/comment/Comment.java
+++ b/aics-core/aics-domain/src/main/java/kgu/developers/core/domain/comment/Comment.java
@@ -41,7 +41,9 @@ public class Comment extends BaseTimeEntity {
 	private User author;
 
 	public static Comment create(String content, User author/*todo: 주석 해제 ,Post post*/) {
-		return Comment.builder().content(content).author(author)
+		return Comment.builder()
+			.content(content)
+			.author(author)
 			//todo: 주석해제 .post(post)
 			.build();
 	}


### PR DESCRIPTION
## Summary

> close #9 

## Tasks

작업 내용: Comment 엔티티 구현

댓글(Comment) 엔티티를 정의하여 댓글 정보를 관리할 수 있도록 함.
id, content, author(작성자) 필드를 포함하여 댓글의 기본 정보를 저장.
BaseTimeEntity를 상속받아 생성일과 수정일을 자동으로 관리.
필드 및 관계 설정

id: 댓글의 고유 식별자.
content: 댓글의 내용 필드, nullable = false로 설정하여 필수 입력 항목으로 지정.
author: 댓글 작성자를 User 엔티티와 연관시킴. ManyToOne 관계로 설정, 지연 로딩(Lazy Loading)을 사용하여 작성자 정보를 필요할 때만 가져오도록 처리.
정적 팩토리 메서드 제공

Comment.create(String content, User author) 메서드를 통해 댓글 생성 시 간편하게 작성자와 내용을 설정할 수 있도록 함.

추가 작업 예정:
Post 엔티티와의 관계 설정은 주석 처리됨. 이후 필요시 활성화하여 댓글이 어느 게시글에 속해 있는지 관리할 예정.
추후에 서비스 레이어 개발 시 메소드 추가 예정

## To Reviewer

빠트린거나 불편한거 언제든지 말씀해주세용

