### PR TITLE
feature/#7 AOP와 인터셉터를 이용한 로깅 시스템 구축

### DIFF
--- a/aics-api/src/main/java/kgu/developers/api/aspect/ExceptionLoggingAspect.java
+++ b/aics-api/src/main/java/kgu/developers/api/aspect/ExceptionLoggingAspect.java
@@ -1,0 +1,45 @@
+package kgu.developers.api.aspect;
+
+import java.util.List;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import kgu.developers.common.exception.CustomException;
+import kgu.developers.globalutils.logging.LoggingUtils;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+@Profile("local")
+public class ExceptionLoggingAspect {
+
+	@Pointcut("execution(public * kgu.developers..*(..)) && "
+		+ "!execution(* kgu.developers.api..application..*(..)) && "
+		+ "!execution(* kgu.developers.common..*(..)) && "
+		+ "!@annotation(kgu.developers.globalutils.annotation.NoLogging) && "
+		+ "!@annotation(org.springframework.boot.context.properties.ConfigurationProperties)"
+	)
+	private void logPointcut() {
+	}
+
+	@AfterThrowing(value = "logPointcut()", throwing = "exception")
+	public void logAfterThrowing(JoinPoint joinPoint, CustomException exception) {
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+		String className = signature.getDeclaringType().getSimpleName();
+
+		List<String> arguments = LoggingUtils.getArguments(joinPoint);
+		String parameterMessage = LoggingUtils.getParameterMessage(arguments);
+
+		log.error("[ERROR] POINT : {} || EXCEPTION : {} || ARGUMENTS : {}", className, exception.getCode().getCode(),
+			parameterMessage);
+		log.error("[ERROR] FINAL POINT : {}", exception.getStackTrace()[0]);
+		log.error("[ERROR] MESSAGE : {}", exception.getMessage());
+	}
+}

--- a/aics-api/src/main/java/kgu/developers/api/aspect/ServerErrorLoggingAspect.java
+++ b/aics-api/src/main/java/kgu/developers/api/aspect/ServerErrorLoggingAspect.java
@@ -1,0 +1,42 @@
+package kgu.developers.api.aspect;
+
+import java.util.List;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import kgu.developers.common.exception.CustomException;
+import kgu.developers.globalutils.logging.LoggingUtils;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+@Profile({"dev", "prod"})
+public class ServerErrorLoggingAspect {
+	@Pointcut("execution(public * kgu.developers..*(..)) && "
+		+ "!execution(* kgu.developers.api..application..*(..)) && "
+		+ "!execution(* kgu.developers.common..*(..)) && "
+		+ "!@annotation(kgu.developers.globalutils.annotation.NoLogging) && "
+		+ "!@annotation(org.springframework.boot.context.properties.ConfigurationProperties)"
+	)
+	private void logPointcut() {
+	}
+
+	@AfterThrowing(value = "logPointcut()", throwing = "exception")
+	public void logAfterThrowing(JoinPoint joinPoint, CustomException exception) {
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+		String className = signature.getDeclaringType().getSimpleName();
+
+		List<String> arguments = LoggingUtils.getArguments(joinPoint);
+		String parameterMessage = LoggingUtils.getParameterMessage(arguments);
+
+		log.error("[ERROR] POINT : {} || EXCEPTION : {} || ARGUMENTS : {}", className, exception.getCode().getCode(),
+			parameterMessage);
+	}
+}

--- a/aics-api/src/main/java/kgu/developers/api/post/application/PostService.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/application/PostService.java
@@ -5,9 +5,9 @@ import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
 import kgu.developers.api.post.presentation.request.PostCreateRequest;
-import kgu.developers.api.user.application.UserService;
 import kgu.developers.api.post.presentation.response.PostPersistResponse;
 import kgu.developers.api.post.presentation.response.PostSummaryPageResponse;
+import kgu.developers.api.user.application.UserService;
 import kgu.developers.common.response.PaginatedListResponse;
 import kgu.developers.domain.post.domain.Post;
 import kgu.developers.domain.post.domain.PostRepository;
@@ -30,14 +30,8 @@ public class PostService {
 
 	@Transactional
 	public PostSummaryPageResponse getPostsByKeyword(PageRequest request, String keyword) {
-		try {
-			PaginatedListResponse<Post> paginatedListResponse = postRepository.findAllByTitleContainingOrderByCreatedAtDesc(
-				keyword, request);
-			return PostSummaryPageResponse.of(paginatedListResponse.contents(), paginatedListResponse.pageable());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-		}
-		return null;
+		PaginatedListResponse<Post> paginatedListResponse = postRepository.findAllByTitleContainingOrderByCreatedAtDesc(
+			keyword, request);
+		return PostSummaryPageResponse.of(paginatedListResponse.contents(), paginatedListResponse.pageable());
 	}
 }

--- a/aics-common/src/main/java/kgu/developers/common/config/WebConfig.java
+++ b/aics-common/src/main/java/kgu/developers/common/config/WebConfig.java
@@ -1,0 +1,19 @@
+package kgu.developers.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import kgu.developers.common.interceptor.LoggingInterceptor;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+	private final LoggingInterceptor loggingInterceptor;
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(loggingInterceptor);
+	}
+}

--- a/aics-common/src/main/java/kgu/developers/common/interceptor/LoggingInterceptor.java
+++ b/aics-common/src/main/java/kgu/developers/common/interceptor/LoggingInterceptor.java
@@ -1,0 +1,43 @@
+package kgu.developers.common.interceptor;
+
+import java.lang.reflect.Method;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
+import kgu.developers.globalutils.annotation.NoLogging;
+import kgu.developers.globalutils.logging.LoggingUtils;
+
+@Component
+public class LoggingInterceptor implements HandlerInterceptor {
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, @NotNull HttpServletResponse response,
+		@NotNull Object handler) {
+		if (isNoLogging(handler)) return true;
+		request.setAttribute("startTime", System.currentTimeMillis());
+		LoggingUtils.logRequest();
+		return true;
+	}
+
+	@Override
+	public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler,
+		Exception ex) {
+		if (isNoLogging(handler)) return;
+		LoggingUtils.logDuration(request, response, ex);
+	}
+
+	private boolean isNoLogging(Object handler) {
+		if (handler instanceof HandlerMethod) {
+			HandlerMethod handlerMethod = (HandlerMethod)handler;
+			Method method = handlerMethod.getMethod();
+
+			return method.isAnnotationPresent(NoLogging.class);
+		}
+		return false;
+	}
+}

--- a/aics-global-utils/src/main/java/kgu/developers/globalutils/annotation/NoLogging.java
+++ b/aics-global-utils/src/main/java/kgu/developers/globalutils/annotation/NoLogging.java
@@ -1,0 +1,11 @@
+package kgu.developers.globalutils.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoLogging {
+}

--- a/aics-global-utils/src/main/java/kgu/developers/globalutils/logging/HttpReqResUtils.java
+++ b/aics-global-utils/src/main/java/kgu/developers/globalutils/logging/HttpReqResUtils.java
@@ -1,0 +1,36 @@
+package kgu.developers.globalutils.logging;
+
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class HttpReqResUtils {
+	private static final String[] IP_HEADER_CANDIDATES = {
+		"X-Forwarded-For",
+		"Proxy-Client-IP",
+		"WL-Proxy-Client-IP",
+		"HTTP_X_FORWARDED_FOR",
+		"HTTP_X_FORWARDED",
+		"HTTP_X_CLUSTER_CLIENT_IP",
+		"HTTP_CLIENT_IP",
+		"HTTP_FORWARDED_FOR",
+		"HTTP_FORWARDED",
+		"HTTP_VIA",
+		"REMOTE_ADDR"
+	};
+
+	public static String getClientIpAddressIfServletRequestExist() {
+		if (RequestContextHolder.getRequestAttributes() == null) {
+			return "0.0.0.0";
+		}
+		HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest();
+		for (String header : IP_HEADER_CANDIDATES) {
+			String ipList = request.getHeader(header);
+			if (ipList != null && !ipList.isEmpty() && !"unknown".equalsIgnoreCase(ipList)) {
+				return ipList.split(",")[0];
+			}
+		}
+		return request.getRemoteAddr();
+	}
+}

--- a/aics-global-utils/src/main/java/kgu/developers/globalutils/logging/LoggingUtils.java
+++ b/aics-global-utils/src/main/java/kgu/developers/globalutils/logging/LoggingUtils.java
@@ -1,0 +1,83 @@
+package kgu.developers.globalutils.logging;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import org.aspectj.lang.JoinPoint;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class LoggingUtils {
+
+	public static List<String> getArguments(JoinPoint joinPoint) {
+		return Arrays.stream(joinPoint.getArgs())
+			.map(LoggingUtils::getObjectFields)
+			.toList();
+	}
+
+	public static String getObjectFields(Object obj) {
+		StringBuilder result = new StringBuilder();
+		Class<?> objClass = obj.getClass();
+		result.append(objClass.getSimpleName()).append(" {");
+
+		Field[] fields = objClass.getDeclaredFields();
+		for (int i = 0; i < fields.length; i++) {
+			fields[i].setAccessible(true);
+			try {
+				result.append(fields[i].getName()).append(" = ")
+					.append(fields[i].get(obj));
+			} catch (IllegalAccessException e) {
+				result.append(fields[i].getName()).append("=ACCESS_DENIED");
+			}
+			if (i < fields.length - 1) {
+				result.append(", ");
+			}
+		}
+		result.append("}");
+		return result.toString();
+	}
+
+	public static String getParameterMessage(List<String> arguments) {
+		if (arguments == null)
+			return "";
+
+		return String.join(" | ", arguments);
+	}
+
+	public static void logRequest() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		String userId =
+			(authentication == null || Objects.equals(authentication.getName(), "anonymousUser")) ? "anonymous" :
+				authentication.getName();
+		String clientIp = HttpReqResUtils.getClientIpAddressIfServletRequestExist();
+
+		log.info("[REQUEST] CLIENT IP : {} || USER ID : {}", clientIp, userId);
+	}
+
+	public static void logDuration(HttpServletRequest request, HttpServletResponse response, Exception ex) {
+		String requestUrl = request.getRequestURI();
+		String httpMethod = request.getMethod();
+		int httpStatus = response.getStatus();
+
+		long startTime = (Long)request.getAttribute("startTime");
+		long endTime = System.currentTimeMillis();
+		long duration = endTime - startTime;
+
+		if (ex == null) {
+			log.info("[DURATION] ENDPOINT : {} {} || STATUS : {} || DURATION : {}ms", httpMethod, requestUrl,
+				httpStatus, duration);
+		} else {
+			log.error("[DURATION] ENDPOINT : {} {} || STATUS : {} || DURATION : {}ms || EXCEPTION : {}",
+				httpMethod, requestUrl, httpStatus, duration, ex.getMessage());
+		}
+	}
+}


### PR DESCRIPTION
## Summary

> close #7 

스프링 AOP와 인터셉터를 이용하여 로깅 시스템을 구축하였습니다.

## Tasks

- 스프링 인터셉터를 활용하여 클라이언트 요청 로그 및 실행 시간을 로그로 남깁니다.
- 스프링 AOP를 활용하여 에러 로그를 추적합니다.

## To Reviewer

1. API에 `@NoLogging` 어노테이션을 붙이면 로그를 남기지 않습니다.
2. REQUEST --> ERROR --> DURATION 순서로 로그가 남겨집니다.

## Screenshot

<img width="1545" alt="스크린샷 2024-10-29 오후 4 21 20" src="https://github.com/user-attachments/assets/aa127c51-cf29-434f-a820-0d17245310ac">

