### PR TITLE
feature/#45-게시글-고정-상태-토글-api

### DIFF
--- a/aics-api/src/main/java/kgu/developers/api/post/application/PostService.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/application/PostService.java
@@ -1,5 +1,8 @@
 package kgu.developers.api.post.application;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
 import jakarta.transaction.Transactional;
 import kgu.developers.api.post.presentation.exception.PostNotFoundException;
 import kgu.developers.api.post.presentation.request.PostRequest;
@@ -12,8 +15,6 @@ import kgu.developers.domain.post.domain.Post;
 import kgu.developers.domain.post.domain.PostRepository;
 import kgu.developers.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -58,5 +59,11 @@ public class PostService {
 
 		updatePost.updateTitle(request.title());
 		updatePost.updateContent(request.content());
+	}
+
+	@Transactional
+	public void togglePinnedStatus(Long postId) {
+		Post pinPost = getById(postId);
+		pinPost.togglePinned();
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/post/application/PostService.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/application/PostService.java
@@ -62,7 +62,7 @@ public class PostService {
 	}
 
 	@Transactional
-	public void togglePinnedStatus(Long postId) {
+	public void togglePostPinStatus(Long postId) {
 		Post pinPost = getById(postId);
 		pinPost.togglePinned();
 	}

--- a/aics-api/src/main/java/kgu/developers/api/post/presentation/PostController.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/presentation/PostController.java
@@ -94,10 +94,10 @@ public class PostController {
 		""")
 	@ApiResponse(responseCode = "204")
 	@PatchMapping("/{postId}/pin")
-	public ResponseEntity<Void> updatePost(
+	public ResponseEntity<Void> togglePostPinStatus(
 		@Parameter(description = "고정 상태를 변경할 게시글의 ID", example = "19", required = true) @PathVariable @Positive Long postId
 	) {
-		postService.togglePinnedStatus(postId);
+		postService.togglePostPinStatus(postId);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/post/presentation/PostController.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/presentation/PostController.java
@@ -1,5 +1,18 @@
 package kgu.developers.api.post.presentation;
 
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -14,18 +27,6 @@ import kgu.developers.api.post.presentation.response.PostDetailResponse;
 import kgu.developers.api.post.presentation.response.PostPersistResponse;
 import kgu.developers.api.post.presentation.response.PostSummaryPageResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
 @RequiredArgsConstructor
@@ -84,6 +85,19 @@ public class PostController {
 		@RequestBody PostRequest request
 	) {
 		postService.updatePost(postId, request);
+		return ResponseEntity.noContent().build();
+	}
+
+	@Operation(summary = "게시글 고정 상태 변경 API", description = """
+		    - Description : 이 API는 지정된 게시글의 고정 여부를 토글하여 고정 또는 해제합니다.
+		    - Assignee : 박민준
+		""")
+	@ApiResponse(responseCode = "204")
+	@PatchMapping("/{postId}/pin")
+	public ResponseEntity<Void> updatePost(
+		@Parameter(description = "고정 상태를 변경할 게시글의 ID", example = "19", required = true) @PathVariable @Positive Long postId
+	) {
+		postService.togglePinnedStatus(postId);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
@@ -56,16 +56,16 @@ public class Post extends BaseTimeEntity {
 	@OneToMany(mappedBy = "post", fetch = LAZY, cascade = ALL, orphanRemoval = true)
 	private List<Comment> comments = new ArrayList<>();
 
-    /* TODO: 파일 엔티티 생성 후 연결 & create 메서드에 추가
-    @OneToOne
-    @JoinColumn(name = "file_id")
-    private FileEntity attachment;
+	/* TODO: 파일 엔티티 생성 후 연결 & create 메서드에 추가
+	@OneToOne
+	@JoinColumn(name = "file_id")
+	private FileEntity attachment;
 
-    public boolean hasAttachment(){
+	public boolean hasAttachment(){
 		return attachment != null;
 	}
-    */
-
+	*/
+	@Column(nullable = false)
 	private boolean isPinned;
 
 	public static Post create(String title, String content, User author) {
@@ -73,6 +73,7 @@ public class Post extends BaseTimeEntity {
 			.title(title)
 			.content(content)
 			.views(0)
+			.isPinned(false)
 			.author(author) // NOTE: User Setter 주입 방지 위해 생성자 주입
 			.build();
 	}

--- a/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
@@ -1,5 +1,14 @@
 package kgu.developers.domain.post.domain;
 
+import static jakarta.persistence.CascadeType.*;
+import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
@@ -15,15 +24,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static jakarta.persistence.CascadeType.ALL;
-import static jakarta.persistence.EnumType.STRING;
-import static jakarta.persistence.FetchType.LAZY;
-import static jakarta.persistence.GenerationType.IDENTITY;
-import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
@@ -66,6 +66,8 @@ public class Post extends BaseTimeEntity {
 	}
     */
 
+	private boolean isPinned;
+
 	public static Post create(String title, String content, User author) {
 		return Post.builder()
 			.title(title)
@@ -85,5 +87,9 @@ public class Post extends BaseTimeEntity {
 
 	public boolean isAuthor(String authorId) {
 		return this.author.getUserId().equals(authorId);
+	}
+
+	public boolean togglePinned() {
+		isPinned = !isPinned;
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
@@ -85,11 +85,7 @@ public class Post extends BaseTimeEntity {
 		this.content = content;
 	}
 
-	public boolean isAuthor(String authorId) {
-		return this.author.getUserId().equals(authorId);
-	}
-
-	public boolean togglePinned() {
+	public void togglePinned() {
 		isPinned = !isPinned;
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/post/infrastructure/QueryPostRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/infrastructure/QueryPostRepository.java
@@ -1,16 +1,18 @@
 package kgu.developers.domain.post.infrastructure;
 
+import static kgu.developers.domain.post.domain.QPost.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import kgu.developers.common.response.PageableResponse;
 import kgu.developers.common.response.PaginatedListResponse;
 import kgu.developers.domain.post.domain.Post;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
-
-import java.util.List;
-
-import static kgu.developers.domain.post.domain.QPost.post;
 
 @Repository
 @RequiredArgsConstructor
@@ -18,13 +20,14 @@ public class QueryPostRepository {
 	private final JPAQueryFactory queryFactory;
 
 	public PaginatedListResponse findAllByTitleContainingOrderByCreatedAtDesc(String keyword,
-																			  Pageable pageable) {
-		if (keyword == null) keyword = "";
+		Pageable pageable) {
+		if (keyword == null)
+			keyword = "";
 		List<Post> posts = queryFactory
 			.select(post)
 			.from(post)
 			.where(post.title.contains(keyword))
-			.orderBy(post.createdAt.desc())
+			.orderBy(post.isPinned.desc(), post.createdAt.desc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();


### PR DESCRIPTION
## Summary

> close #45 

**게시글 고정 상태 토글 로직 구현**

## Tasks

- 게시글 고정 상태를 토글하는 로직 추가.
- 게시글 목록 조회 시 고정 상태인 게시글을 우선으로 조회.
