### PR TITLE
feature/#60 댓글 수정 기능

### DIFF
--- a/aics-api/src/main/java/kgu/developers/api/comment/application/CommentService.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/application/CommentService.java
@@ -1,6 +1,8 @@
 package kgu.developers.api.comment.application;
 
 import jakarta.transaction.Transactional;
+import jakarta.validation.constraints.Positive;
+import kgu.developers.api.comment.presentation.exception.CommentNotFoundException;
 import kgu.developers.api.comment.presentation.request.CommentRequest;
 import kgu.developers.api.comment.presentation.response.CommentPersistResponse;
 import kgu.developers.api.post.application.PostService;
@@ -26,5 +28,17 @@ public class CommentService {
 		);
 		Long id = commentRepository.save(createComment).getId();
 		return CommentPersistResponse.of(id);
+	}
+
+	@Transactional
+	public void updateComment(@Positive Long commentId, CommentRequest commentRequest) {
+		Comment comment = getById(commentId);
+		comment.updateContent(commentRequest.content());
+	}
+
+	private Comment getById(Long commentId) {
+		return commentRepository.findById(commentId)
+			.filter(comment -> comment.getDeletedAt() == null)
+			.orElseThrow(CommentNotFoundException::new);
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/comment/application/CommentService.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/application/CommentService.java
@@ -1,7 +1,6 @@
 package kgu.developers.api.comment.application;
 
 import jakarta.transaction.Transactional;
-import jakarta.validation.constraints.Positive;
 import kgu.developers.api.comment.presentation.exception.CommentNotFoundException;
 import kgu.developers.api.comment.presentation.request.CommentRequest;
 import kgu.developers.api.comment.presentation.response.CommentPersistResponse;
@@ -31,7 +30,7 @@ public class CommentService {
 	}
 
 	@Transactional
-	public void updateComment(@Positive Long commentId, CommentRequest commentRequest) {
+	public void updateComment(Long commentId, CommentRequest commentRequest) {
 		Comment comment = getById(commentId);
 		comment.updateContent(commentRequest.content());
 	}

--- a/aics-api/src/main/java/kgu/developers/api/comment/presentation/CommentController.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/presentation/CommentController.java
@@ -1,16 +1,20 @@
 package kgu.developers.api.comment.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
 import kgu.developers.api.comment.application.CommentService;
 import kgu.developers.api.comment.presentation.request.CommentRequest;
 import kgu.developers.api.comment.presentation.response.CommentPersistResponse;
 import kgu.developers.api.comment.presentation.response.CommentResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,6 +40,20 @@ public class CommentController {
 	) {
 		CommentPersistResponse response = commentService.createComment(commentRequest);
 		return ResponseEntity.status(CREATED).body(response);
+	}
+
+	@Operation(summary = "댓글 수정 API", description = """
+			- Description : 이 API는 댓글을 수정합니다.
+			- Assignee : 이신행
+		""")
+	@ApiResponse(responseCode = "204")
+	@PatchMapping("/{commentId}")
+	public ResponseEntity<Void> updateComment(
+		@Parameter(description = "수정할 게시글의 ID", example = "19", required = true) @PathVariable @Positive Long commentId,
+		@RequestBody CommentRequest commentRequest
+	) {
+		commentService.updateComment(commentId, commentRequest);
+		return ResponseEntity.noContent().build();
 	}
 
 

--- a/aics-api/src/main/java/kgu/developers/api/comment/presentation/exception/CommentExceptionCode.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/presentation/exception/CommentExceptionCode.java
@@ -1,0 +1,22 @@
+package kgu.developers.api.comment.presentation.exception;
+
+import kgu.developers.common.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum CommentExceptionCode implements ExceptionCode {
+	COMMENT_NOT_FOUND_EXCEPTION(NOT_FOUND, "해당 ID의 댓글이 없습니다.");
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public String getCode() {
+		return this.name();
+	}
+}

--- a/aics-api/src/main/java/kgu/developers/api/comment/presentation/exception/CommentNotFoundException.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/presentation/exception/CommentNotFoundException.java
@@ -1,0 +1,11 @@
+package kgu.developers.api.comment.presentation.exception;
+
+import kgu.developers.common.exception.CustomException;
+
+import static kgu.developers.api.comment.presentation.exception.CommentExceptionCode.COMMENT_NOT_FOUND_EXCEPTION;
+
+public class CommentNotFoundException extends CustomException {
+	public CommentNotFoundException() {
+		super(COMMENT_NOT_FOUND_EXCEPTION);
+	}
+}

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/domain/Comment.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/domain/Comment.java
@@ -1,8 +1,5 @@
 package kgu.developers.domain.comment.domain;
 
-import static jakarta.persistence.FetchType.*;
-import static jakarta.persistence.GenerationType.*;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -16,6 +13,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.FetchType.EAGER;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
 @Getter
@@ -45,6 +48,11 @@ public class Comment extends BaseTimeEntity {
 			.author(author)
 			.post(post)
 			.build();
+	}
+
+	public void updateContent(String content) {
+		this.content = content;
+		this.updatedAt = LocalDateTime.now();
 	}
 
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/domain/Comment.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/domain/Comment.java
@@ -14,8 +14,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 import static jakarta.persistence.FetchType.EAGER;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -52,7 +50,6 @@ public class Comment extends BaseTimeEntity {
 
 	public void updateContent(String content) {
 		this.content = content;
-		this.updatedAt = LocalDateTime.now();
 	}
 
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/domain/CommentRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/domain/CommentRepository.java
@@ -1,5 +1,9 @@
 package kgu.developers.domain.comment.domain;
 
+import java.util.Optional;
+
 public interface CommentRepository {
 	Comment save(Comment comment);
+
+	Optional<Comment> findById(Long commentId);
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/CommentRepositoryImpl.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/CommentRepositoryImpl.java
@@ -5,6 +5,8 @@ import kgu.developers.domain.comment.domain.CommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class CommentRepositoryImpl implements CommentRepository {
@@ -13,5 +15,10 @@ public class CommentRepositoryImpl implements CommentRepository {
 	@Override
 	public Comment save(Comment comment) {
 		return jpaCommentRepository.save(comment);
+	}
+
+	@Override
+	public Optional<Comment> findById(Long commentId) {
+		return jpaCommentRepository.findById(commentId);
 	}
 }


### PR DESCRIPTION
## Summary

> close #60 

## Tasks

- 댓글 수정 기능 구현

## To Reviewer

원래 있던 request 객체를 재사용했습니다.
CommentRequest 객체의 postId는 NotBlank로 어떠한 값이든 전달이 되어야 하지만, 
비즈니스로직에서 postId를 사용하거나 변경하지 않기 때문에
실제 댓글이 달린 postId와 일치하는지 검증하는 로직은 일부러 넣지 않았습니다.

content만 전달받는 request 객체를 새로 만들어서 요청시 입력 받는게 좋을까요? 아니면 현재 그대로 유지하는게 좋을까요?

