### PR TITLE
feature/#58 게시글 댓글 조회 api 구현

### DIFF
--- a/aics-api/src/main/java/kgu/developers/api/comment/application/CommentService.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/application/CommentService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
+import kgu.developers.api.comment.presentation.exception.CommentNotFoundException;
 import kgu.developers.api.comment.presentation.request.CommentListRequest;
 import kgu.developers.api.comment.presentation.request.CommentRequest;
 import kgu.developers.api.comment.presentation.response.CommentListResponse;
@@ -37,5 +38,17 @@ public class CommentService {
 		List<Comment> comments = commentRepository.findByPostId(request.postId());
 
 		return CommentListResponse.from(comments);
+	}
+
+	@Transactional
+	public void updateComment(Long commentId, CommentRequest commentRequest) {
+		Comment comment = getById(commentId);
+		comment.updateContent(commentRequest.content());
+	}
+
+	private Comment getById(Long commentId) {
+		return commentRepository.findById(commentId)
+			.filter(comment -> comment.getDeletedAt() == null)
+			.orElseThrow(CommentNotFoundException::new);
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/comment/application/CommentService.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/application/CommentService.java
@@ -34,7 +34,7 @@ public class CommentService {
 		return CommentPersistResponse.of(id);
 	}
 
-	public CommentListResponse readComments(CommentListRequest request) {
+	public CommentListResponse getComments(CommentListRequest request) {
 		List<Comment> comments = commentRepository.findByPostId(request.postId());
 
 		return CommentListResponse.from(comments);

--- a/aics-api/src/main/java/kgu/developers/api/comment/application/CommentService.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/application/CommentService.java
@@ -35,7 +35,7 @@ public class CommentService {
 	}
 
 	public CommentListResponse getComments(CommentListRequest request) {
-		List<Comment> comments = commentRepository.findByPostId(request.postId());
+		List<Comment> comments = commentRepository.findAllByPostIdAndDeletedAtIsNull(request.postId());
 
 		return CommentListResponse.from(comments);
 	}

--- a/aics-api/src/main/java/kgu/developers/api/comment/application/CommentService.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/application/CommentService.java
@@ -1,14 +1,19 @@
 package kgu.developers.api.comment.application;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
 import jakarta.transaction.Transactional;
+import kgu.developers.api.comment.presentation.request.CommentListRequest;
 import kgu.developers.api.comment.presentation.request.CommentRequest;
+import kgu.developers.api.comment.presentation.response.CommentListResponse;
 import kgu.developers.api.comment.presentation.response.CommentPersistResponse;
 import kgu.developers.api.post.application.PostService;
 import kgu.developers.api.user.application.UserService;
 import kgu.developers.domain.comment.domain.Comment;
 import kgu.developers.domain.comment.domain.CommentRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -26,5 +31,11 @@ public class CommentService {
 		);
 		Long id = commentRepository.save(createComment).getId();
 		return CommentPersistResponse.of(id);
+	}
+
+	public CommentListResponse readComments(CommentListRequest request) {
+		List<Comment> comments = commentRepository.findByPostId(request.postId());
+
+		return CommentListResponse.from(comments);
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/comment/presentation/CommentController.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/presentation/CommentController.java
@@ -66,10 +66,10 @@ public class CommentController {
 		""")
 	@ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = CommentListResponse.class)))
 	@GetMapping
-	public ResponseEntity<CommentListResponse> readComments(
+	public ResponseEntity<CommentListResponse> getComments(
 		@RequestBody CommentListRequest commentListRequest
 	) {
-		CommentListResponse response = commentService.readComments(commentListRequest);
+		CommentListResponse response = commentService.getComments(commentListRequest);
 		return ResponseEntity.ok(response);
 	}
 

--- a/aics-api/src/main/java/kgu/developers/api/comment/presentation/CommentController.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/presentation/CommentController.java
@@ -1,5 +1,16 @@
 package kgu.developers.api.comment.presentation;
 
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -14,15 +25,6 @@ import kgu.developers.api.comment.presentation.response.CommentListResponse;
 import kgu.developers.api.comment.presentation.response.CommentPersistResponse;
 import kgu.developers.api.comment.presentation.response.CommentResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
 @RequiredArgsConstructor

--- a/aics-api/src/main/java/kgu/developers/api/comment/presentation/CommentController.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/presentation/CommentController.java
@@ -1,22 +1,26 @@
 package kgu.developers.api.comment.presentation;
 
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kgu.developers.api.comment.application.CommentService;
+import kgu.developers.api.comment.presentation.request.CommentListRequest;
 import kgu.developers.api.comment.presentation.request.CommentRequest;
+import kgu.developers.api.comment.presentation.response.CommentListResponse;
 import kgu.developers.api.comment.presentation.response.CommentPersistResponse;
 import kgu.developers.api.comment.presentation.response.CommentResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,7 +34,7 @@ public class CommentController {
 			- Assignee : 이신행
 		""")
 	@ApiResponse(responseCode = "201", content = @Content(schema = @Schema(implementation = CommentResponse.class)))
-	@PostMapping()
+	@PostMapping
 	public ResponseEntity<CommentPersistResponse> createComment(
 		@RequestBody CommentRequest commentRequest
 	) {
@@ -38,5 +42,17 @@ public class CommentController {
 		return ResponseEntity.status(CREATED).body(response);
 	}
 
+	@Operation(summary = "댓글 조회 API", description = """
+			- Description : 이 API는 해당 게시글의 댓글을 조회합니다.
+			- Assignee : 박민준
+		""")
+	@ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = CommentListResponse.class)))
+	@GetMapping
+	public ResponseEntity<CommentListResponse> readComments(
+		@RequestBody CommentListRequest commentListRequest
+	) {
+		CommentListResponse response = commentService.readComments(commentListRequest);
+		return ResponseEntity.ok(response);
+	}
 
 }

--- a/aics-api/src/main/java/kgu/developers/api/comment/presentation/request/CommentListRequest.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/presentation/request/CommentListRequest.java
@@ -3,11 +3,13 @@ package kgu.developers.api.comment.presentation.request;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public record CommentListRequest(
 	@Schema(description = "게시물 아이디", example = "10", requiredMode = REQUIRED)
-	@NotBlank
+	@NotNull
+	@Positive
 	Long postId
 ) {
 }

--- a/aics-api/src/main/java/kgu/developers/api/comment/presentation/request/CommentListRequest.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/presentation/request/CommentListRequest.java
@@ -1,0 +1,13 @@
+package kgu.developers.api.comment.presentation.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record CommentListRequest(
+	@Schema(description = "게시물 아이디", example = "10", requiredMode = REQUIRED)
+	@NotBlank
+	Long postId
+) {
+}

--- a/aics-api/src/main/java/kgu/developers/api/comment/presentation/request/CommentRequest.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/presentation/request/CommentRequest.java
@@ -1,16 +1,16 @@
 package kgu.developers.api.comment.presentation.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Builder;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
-
-
-@Builder
 public record CommentRequest(
 	@Schema(description = "게시물 아이디", example = "10", requiredMode = REQUIRED)
-	@NotBlank
+	@NotNull
+	@Positive
 	Long postId,
 
 	@Schema(description = "댓글 내용", example = "예시 코멘트 입니다~~", requiredMode = REQUIRED)

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/domain/CommentRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/domain/CommentRepository.java
@@ -1,5 +1,9 @@
 package kgu.developers.domain.comment.domain;
 
+import java.util.List;
+
 public interface CommentRepository {
 	Comment save(Comment comment);
+
+	List<Comment> findByPostId(Long postId);
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/domain/CommentRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/domain/CommentRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 public interface CommentRepository {
 	Comment save(Comment comment);
 
-	List<Comment> findByPostId(Long postId);
+	List<Comment> findAllByPostIdAndDeletedAtIsNull(Long postId);
 
 	Optional<Comment> findById(Long commentId);
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/domain/CommentRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/domain/CommentRepository.java
@@ -1,7 +1,6 @@
 package kgu.developers.domain.comment.domain;
 
 import java.util.List;
-
 import java.util.Optional;
 
 public interface CommentRepository {

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/CommentRepositoryImpl.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/CommentRepositoryImpl.java
@@ -1,9 +1,12 @@
 package kgu.developers.domain.comment.infrastructure;
 
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
 import kgu.developers.domain.comment.domain.Comment;
 import kgu.developers.domain.comment.domain.CommentRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -13,5 +16,10 @@ public class CommentRepositoryImpl implements CommentRepository {
 	@Override
 	public Comment save(Comment comment) {
 		return jpaCommentRepository.save(comment);
+	}
+
+	@Override
+	public List<Comment> findByPostId(Long postId) {
+		return jpaCommentRepository.findByPostId(postId);
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/CommentRepositoryImpl.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/CommentRepositoryImpl.java
@@ -26,6 +26,6 @@ public class CommentRepositoryImpl implements CommentRepository {
 
 	@Override
 	public List<Comment> findByPostId(Long postId) {
-		return jpaCommentRepository.findByPostId(postId);
+		return jpaCommentRepository.findByPostIdAndDeletedAtIsNull(postId);
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/CommentRepositoryImpl.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/CommentRepositoryImpl.java
@@ -1,15 +1,13 @@
 package kgu.developers.domain.comment.infrastructure;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
 import kgu.developers.domain.comment.domain.Comment;
 import kgu.developers.domain.comment.domain.CommentRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/CommentRepositoryImpl.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/CommentRepositoryImpl.java
@@ -25,7 +25,7 @@ public class CommentRepositoryImpl implements CommentRepository {
 	}
 
 	@Override
-	public List<Comment> findByPostId(Long postId) {
-		return jpaCommentRepository.findByPostIdAndDeletedAtIsNull(postId);
+	public List<Comment> findAllByPostIdAndDeletedAtIsNull(Long postId) {
+		return jpaCommentRepository.findAllByPostIdAndDeletedAtIsNull(postId);
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/JpaCommentRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/JpaCommentRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import kgu.developers.domain.comment.domain.Comment;
 
 public interface JpaCommentRepository extends JpaRepository<Comment, Long> {
-	List<Comment> findByPostIdAndDeletedAtIsNull(Long postId);
+	List<Comment> findAllByPostIdAndDeletedAtIsNull(Long postId);
 
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/JpaCommentRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/JpaCommentRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import kgu.developers.domain.comment.domain.Comment;
 
 public interface JpaCommentRepository extends JpaRepository<Comment, Long> {
-	List<Comment> findByPostId(Long postId);
+	List<Comment> findByPostIdAndDeletedAtIsNull(Long postId);
+
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/JpaCommentRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/infrastructure/JpaCommentRepository.java
@@ -1,7 +1,11 @@
 package kgu.developers.domain.comment.infrastructure;
 
-import kgu.developers.domain.comment.domain.Comment;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import kgu.developers.domain.comment.domain.Comment;
+
 public interface JpaCommentRepository extends JpaRepository<Comment, Long> {
+	List<Comment> findByPostId(Long postId);
 }


### PR DESCRIPTION
## Summary

> close #58 

**댓글 조회 기능 관련 DTO 및 Repository 구현**

## Tasks

- 댓글 조회를 위한 요청 DTO(CommentReadRequest) 구현
- JpaCommentRepository에 댓글 조회 메서드(findByPostIdOrderByCreatedAtDesc) 추가
- 댓글 조회 로직 구현
- 병합 충돌 해결 후 누락된 코드 반영

