### PR TITLE
refactor/#69 게시글 존재 여부 확인 및 사소한 수정

### DIFF
--- a/aics-api/src/main/java/kgu/developers/api/comment/application/CommentService.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/application/CommentService.java
@@ -16,6 +16,7 @@ import kgu.developers.api.post.application.PostService;
 import kgu.developers.api.user.application.UserService;
 import kgu.developers.domain.comment.domain.Comment;
 import kgu.developers.domain.comment.domain.CommentRepository;
+import kgu.developers.domain.post.domain.Post;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -41,7 +42,8 @@ public class CommentService {
 	}
 
 	public CommentListResponse getComments(Long postId) {
-		List<Comment> comments = commentRepository.findAllByPostIdAndDeletedAtIsNull(postId);
+		Post post = postService.getById(postId);
+		List<Comment> comments = commentRepository.findAllByPostIdAndDeletedAtIsNull(post.getId());
 		return CommentListResponse.from(comments);
 	}
 

--- a/aics-api/src/main/java/kgu/developers/api/comment/presentation/exception/CommentExceptionCode.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/presentation/exception/CommentExceptionCode.java
@@ -10,7 +10,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @Getter
 @AllArgsConstructor
 public enum CommentExceptionCode implements ExceptionCode {
-	COMMENT_NOT_FOUND_EXCEPTION(NOT_FOUND, "해당 ID의 댓글이 없습니다.");
+	COMMENT_NOT_FOUND(NOT_FOUND, "해당 ID의 댓글이 없습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/aics-api/src/main/java/kgu/developers/api/comment/presentation/exception/CommentNotFoundException.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/presentation/exception/CommentNotFoundException.java
@@ -2,10 +2,10 @@ package kgu.developers.api.comment.presentation.exception;
 
 import kgu.developers.common.exception.CustomException;
 
-import static kgu.developers.api.comment.presentation.exception.CommentExceptionCode.COMMENT_NOT_FOUND_EXCEPTION;
+import static kgu.developers.api.comment.presentation.exception.CommentExceptionCode.COMMENT_NOT_FOUND;
 
 public class CommentNotFoundException extends CustomException {
 	public CommentNotFoundException() {
-		super(COMMENT_NOT_FOUND_EXCEPTION);
+		super(COMMENT_NOT_FOUND);
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/file/presentation/exception/FileExceptionCode.java
+++ b/aics-api/src/main/java/kgu/developers/api/file/presentation/exception/FileExceptionCode.java
@@ -10,7 +10,7 @@ import static org.springframework.http.HttpStatus.*;
 @Getter
 @AllArgsConstructor
 public enum FileExceptionCode implements ExceptionCode {
-	FILE_SAVING_EXCEPTION(INTERNAL_SERVER_ERROR, "파일 저장이 되지 않았습니다.")
+	FILE_SAVING_ERROR(BAD_REQUEST, "파일 저장이 되지 않았습니다.")
 	;
 
 	private final HttpStatus status;

--- a/aics-api/src/main/java/kgu/developers/api/file/presentation/exception/FileSavingException.java
+++ b/aics-api/src/main/java/kgu/developers/api/file/presentation/exception/FileSavingException.java
@@ -2,10 +2,10 @@ package kgu.developers.api.file.presentation.exception;
 
 import kgu.developers.common.exception.CustomException;
 
-import static kgu.developers.api.file.presentation.exception.FileExceptionCode.FILE_SAVING_EXCEPTION;
+import static kgu.developers.api.file.presentation.exception.FileExceptionCode.FILE_SAVING_ERROR;
 
 public class FileSavingException extends CustomException {
 	public FileSavingException() {
-		super(FILE_SAVING_EXCEPTION);
+		super(FILE_SAVING_ERROR);
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/post/presentation/exception/PostExceptionCode.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/presentation/exception/PostExceptionCode.java
@@ -10,7 +10,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @Getter
 @AllArgsConstructor
 public enum PostExceptionCode implements ExceptionCode {
-	POST_NOT_FOUND_EXCEPTION(NOT_FOUND, "해당 ID의 게시글이 없습니다.");
+	POST_NOT_FOUND(NOT_FOUND, "해당 ID의 게시글이 없습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/aics-api/src/main/java/kgu/developers/api/post/presentation/exception/PostNotFoundException.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/presentation/exception/PostNotFoundException.java
@@ -2,10 +2,10 @@ package kgu.developers.api.post.presentation.exception;
 
 import kgu.developers.common.exception.CustomException;
 
-import static kgu.developers.api.post.presentation.exception.PostExceptionCode.POST_NOT_FOUND_EXCEPTION;
+import static kgu.developers.api.post.presentation.exception.PostExceptionCode.POST_NOT_FOUND;
 
 public class PostNotFoundException extends CustomException {
 	public PostNotFoundException() {
-		super(POST_NOT_FOUND_EXCEPTION);
+		super(POST_NOT_FOUND);
 	}
 }


### PR DESCRIPTION
## Summary

> close #69 

게시글 존재 여부 확인 및 사소한 수정

## Tasks

- 게시글 기반 댓글 조회 시, 게시글 존재 여부 확인
- 예외 네이밍 컨벤션에 맞게 수정
- `FILE_SAVING_ERROR` 500 --> 400 으로 핸들링

