### PR TITLE
fix/#111 배포 스크립트 에러 수정

### DIFF
--- a/.github/workflows/dev-build-deploy.yml
+++ b/.github/workflows/dev-build-deploy.yml
@@ -61,5 +61,5 @@ jobs:
           password: ${{ secrets.SERVER_PASSWORD }}
           port: ${{ secrets.SERVER_PORT }}
           script: |
-            sudo -E docker-compose -f ${{ secrets.DOCKER_COMPOSE_YAML_PATH }} pull || exit 1
-            sudo -E docker-compose -f ${{ secrets.DOCKER_COMPOSE_YAML_PATH }} up -d || exit 1
+            echo "${{ secrets.SERVER_PASSWORD }}" | sudo -S docker-compose -f ${{ secrets.DOCKER_COMPOSE_YAML_PATH }} pull
+            echo "${{ secrets.SERVER_PASSWORD }}" | sudo -S docker-compose -f ${{ secrets.DOCKER_COMPOSE_YAML_PATH }} up -d


### PR DESCRIPTION
## Summary

> resolved #114 

GitHub Actions의 비대화형 환경에서 비밀번호를 받을 수 없는 문제를 해결합니다

## Tasks

- 배포 스크립트 에러 수정
