### PR TITLE
feature/#110 testfixtures 기반 professor testcode 구현

### DIFF
--- a/aics-api/src/main/java/kgu/developers/api/professor/application/ProfessorService.java
+++ b/aics-api/src/main/java/kgu/developers/api/professor/application/ProfessorService.java
@@ -10,8 +10,10 @@ import kgu.developers.api.professor.presentation.request.ProfessorRequest;
 import kgu.developers.api.professor.presentation.response.ProfessorPersistResponse;
 import kgu.developers.domain.professor.domain.Professor;
 import kgu.developers.domain.professor.domain.ProfessorRepository;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 
+@Builder
 @Service
 @RequiredArgsConstructor
 public class ProfessorService {

--- a/aics-api/src/main/java/kgu/developers/api/professor/application/ProfessorService.java
+++ b/aics-api/src/main/java/kgu/developers/api/professor/application/ProfessorService.java
@@ -22,14 +22,14 @@ public class ProfessorService {
 	@Transactional
 	public ProfessorPersistResponse createProfessor(ProfessorRequest request) {
 		Professor professor = Professor.create(request.name(), request.role(), request.contact(), request.email());
-		professorRepository.save(professor);
+		Long id = professorRepository.save(professor).getId();
 
-		return ProfessorPersistResponse.of(professor.getId());
+		return ProfessorPersistResponse.of(id);
 	}
 
 	@Transactional
 	public void updateProfessor(Long id, ProfessorRequest request) {
-		Professor professor = getProfessor(id);
+		Professor professor = getProfessorById(id);
 		professor.updateName(request.name());
 		professor.updateEmail(request.email());
 		professor.updateContact(request.contact());
@@ -38,8 +38,7 @@ public class ProfessorService {
 
 	@Transactional
 	public void deleteProfessor(Long id) {
-		Professor professor = getProfessor(id);
-		professorRepository.delete(professor);
+		professorRepository.deleteById(id);
 	}
 
 	@Transactional(readOnly = true)
@@ -47,7 +46,8 @@ public class ProfessorService {
 		return professorRepository.findAllOrderByRoleAndName();
 	}
 
-	private Professor getProfessor(Long id) {
+	@Transactional(readOnly = true)
+	public Professor getProfessorById(Long id) {
 		return professorRepository.findById(id)
 			.orElseThrow(ProfessorNotFoundException::new);
 	}

--- a/aics-api/src/main/java/kgu/developers/api/professor/presentation/ProfessorController.java
+++ b/aics-api/src/main/java/kgu/developers/api/professor/presentation/ProfessorController.java
@@ -27,8 +27,10 @@ import kgu.developers.api.professor.presentation.request.ProfessorRequest;
 import kgu.developers.api.professor.presentation.response.ProfessorListResponse;
 import kgu.developers.api.professor.presentation.response.ProfessorPersistResponse;
 import kgu.developers.domain.professor.domain.Professor;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 
+@Builder
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/professors")

--- a/aics-api/src/main/java/kgu/developers/api/professor/presentation/request/ProfessorRequest.java
+++ b/aics-api/src/main/java/kgu/developers/api/professor/presentation/request/ProfessorRequest.java
@@ -6,7 +6,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import kgu.developers.domain.professor.domain.Role;
+import lombok.Builder;
 
+@Builder
 public record ProfessorRequest(
 	@Schema(description = "교수 이름", example = "이은정", requiredMode = REQUIRED)
 	@NotNull

--- a/aics-api/src/testFixtures/java/professor/application/ProfessorServiceTest.java
+++ b/aics-api/src/testFixtures/java/professor/application/ProfessorServiceTest.java
@@ -1,4 +1,131 @@
 package professor.application;
 
+import static kgu.developers.domain.professor.domain.Role.ASSISTANT;
+import static kgu.developers.domain.professor.domain.Role.PROFESSOR;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kgu.developers.api.professor.application.ProfessorService;
+import kgu.developers.api.professor.presentation.exception.ProfessorNotFoundException;
+import kgu.developers.api.professor.presentation.request.ProfessorRequest;
+import kgu.developers.api.professor.presentation.response.ProfessorPersistResponse;
+import kgu.developers.domain.professor.domain.Professor;
+import mock.FakeProfessorRepository;
+
 public class ProfessorServiceTest {
+	private ProfessorService professorService;
+
+	@BeforeEach
+	public void init() {
+		FakeProfessorRepository fakeProfessorRepository = new FakeProfessorRepository();
+
+		this.professorService = ProfessorService.builder()
+			.professorRepository(fakeProfessorRepository)
+			.build();
+
+		fakeProfessorRepository.save(Professor.builder()
+			.email("alswns11346@kyonggi.ac.kr")
+			.name("박민준")
+			.role(ASSISTANT)
+			.contact("010-1234-5678")
+			.build());
+
+		fakeProfessorRepository.save(Professor.builder()
+			.email("alswns11346@kgu.ac.kr")
+			.name("박민준")
+			.role(PROFESSOR)
+			.contact("010-1234-5678")
+			.build());
+
+		fakeProfessorRepository.save(Professor.builder()
+			.email("kkh@kyonggi.ac.kr")
+			.name("권기현")
+			.role(PROFESSOR)
+			.contact("010-1234-5678")
+			.build());
+	}
+
+	@Test
+	@DisplayName("createProfessor는 교수를 생성할 수 있다")
+	public void createProfessor_Success() {
+		// given
+		ProfessorRequest request = ProfessorRequest.builder()
+			.name("권기현")
+			.role(PROFESSOR)
+			.email("kkh1111@kgu.ac.kr")
+			.contact("010-1234-5678")
+			.build();
+
+		// when
+		ProfessorPersistResponse response = professorService.createProfessor(request);
+
+		// then
+		assertEquals(4, response.id());
+	}
+
+	@Test
+	@DisplayName("updateProfessor는 교수 정보를 수정할 수 있다")
+	public void updateProfessor_Success() {
+		// given
+		Long professorId = 2L;
+		ProfessorRequest request = new ProfessorRequest("박민준", PROFESSOR, "010-9999-8888",
+			"alswnszzang1@kyonggi.ac.kr");
+
+		// when
+		professorService.updateProfessor(professorId, request);
+		Professor result = professorService.getProfessorById(professorId);
+
+		// then
+		assertEquals("alswnszzang1@kyonggi.ac.kr", result.getEmail());
+	}
+
+	@Test
+	@DisplayName("getProfessor는 존재하지 않는 교수를 찾아올 경우 ProfessorNotFoundException을 발생시킨다.")
+	public void getProfessor_NotFound_ThrowsException() {
+		// given
+		Long professorId = 4L;
+
+		// when
+		// then
+		assertThatThrownBy(() -> {
+			professorService.getProfessorById(professorId);
+		}).isInstanceOf(ProfessorNotFoundException.class);
+	}
+
+	@Test
+	@DisplayName("deleteProfessor는 교수를 삭제할 수 있다")
+	public void deleteProfessor_Success() {
+		// given
+		Long professorId = 1L;
+
+		// when
+		professorService.deleteProfessor(professorId);
+
+		// then
+		assertThatThrownBy(() -> {
+			professorService.getProfessorById(professorId);
+		}).isInstanceOf(ProfessorNotFoundException.class);
+	}
+
+	@Test
+	@DisplayName("getSortedProfessorList는 정렬된 교수 리스트를 반환한다")
+	public void getSortedProfessorList_Success() {
+		// when
+		List<Professor> result = professorService.getSortedProfessorList();
+
+		// then
+		assertEquals(3, result.size());
+		assertEquals("권기현", result.get(0).getName());
+		assertEquals(PROFESSOR, result.get(0).getRole());
+		assertEquals("박민준", result.get(1).getName());
+		assertEquals(PROFESSOR, result.get(1).getRole());
+		assertEquals("박민준", result.get(2).getName());
+		assertEquals(ASSISTANT, result.get(2).getRole());
+	}
 }

--- a/aics-api/src/testFixtures/java/professor/application/ProfessorServiceTest.java
+++ b/aics-api/src/testFixtures/java/professor/application/ProfessorServiceTest.java
@@ -64,9 +64,14 @@ public class ProfessorServiceTest {
 
 		// when
 		ProfessorPersistResponse response = professorService.createProfessor(request);
+		Professor result = Professor.create(request.name(), request.role(), request.contact(), request.email());
 
 		// then
 		assertEquals(4, response.id());
+		assertEquals("권기현", result.getName());
+		assertEquals("kkh1111@kgu.ac.kr", result.getEmail());
+		assertEquals("010-1234-5678", result.getContact());
+		assertEquals(PROFESSOR, result.getRole());
 	}
 
 	@Test
@@ -79,10 +84,13 @@ public class ProfessorServiceTest {
 
 		// when
 		professorService.updateProfessor(professorId, request);
-		Professor result = professorService.getProfessorById(professorId);
+		Professor response = professorService.getProfessorById(professorId);
 
 		// then
-		assertEquals("alswnszzang1@kyonggi.ac.kr", result.getEmail());
+		assertEquals("박민준", response.getName());
+		assertEquals(PROFESSOR, response.getRole());
+		assertEquals("010-9999-8888", response.getContact());
+		assertEquals("alswnszzang1@kyonggi.ac.kr", response.getEmail());
 	}
 
 	@Test

--- a/aics-api/src/testFixtures/java/professor/application/ProfessorServiceTest.java
+++ b/aics-api/src/testFixtures/java/professor/application/ProfessorServiceTest.java
@@ -1,0 +1,4 @@
+package professor.application;
+
+public class ProfessorServiceTest {
+}

--- a/aics-api/src/testFixtures/java/professor/presentation/ProfessorControllerTest.java
+++ b/aics-api/src/testFixtures/java/professor/presentation/ProfessorControllerTest.java
@@ -1,0 +1,4 @@
+package professor.presentation;
+
+public class ProfessorControllerTest {
+}

--- a/aics-domain/src/main/java/kgu/developers/domain/professor/domain/ProfessorRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/professor/domain/ProfessorRepository.java
@@ -10,5 +10,5 @@ public interface ProfessorRepository {
 
 	List<Professor> findAllOrderByRoleAndName();
 
-	void delete(Professor professor);
+	void deleteById(Long id);
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/professor/infrastructure/ProfessorRepositoryImpl.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/professor/infrastructure/ProfessorRepositoryImpl.java
@@ -31,7 +31,7 @@ public class ProfessorRepositoryImpl implements ProfessorRepository {
 	}
 
 	@Override
-	public void delete(Professor professor) {
-		jpaProfessorRepository.delete(professor);
+	public void deleteById(Long id) {
+		jpaProfessorRepository.deleteById(id);
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
@@ -6,6 +6,12 @@ import static jakarta.persistence.FetchType.LAZY;
 import static kgu.developers.domain.user.domain.DeptCode.isValidDeptCode;
 import static lombok.AccessLevel.PROTECTED;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
@@ -20,15 +26,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 
 @Entity
 @Getter
@@ -113,9 +113,17 @@ public class User extends BaseTimeEntity implements UserDetails {
 			throw new DeptCodeNotValidException();
 	}
 
-	private static final String ACCESSIBLE_EMAIL_DOMAIN = "@kyonggi.ac.kr";
+	private static final List<String> ACCESSIBLE_EMAIL_DOMAINS = List.of(
+		"@kyonggi.ac.kr",
+		"@kgu.ac.kr"
+	);
 
 	private static boolean isValidEmailDomain(String email) {
-		return email != null && email.endsWith(ACCESSIBLE_EMAIL_DOMAIN);
+		if (email == null) {
+			return false;
+		}
+
+		return ACCESSIBLE_EMAIL_DOMAINS.stream()
+			.anyMatch(email::endsWith);
 	}
 }

--- a/aics-domain/src/testFixtures/java/mock/FakeProfessorRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/FakeProfessorRepository.java
@@ -49,11 +49,6 @@ public class FakeProfessorRepository implements ProfessorRepository {
 	}
 
 	@Override
-	public void delete(Professor professor) {
-		data.removeIf(p -> p.getId().equals(professor.getId()));
-	}
-
-	// 추가: ID로 삭제하는 메서드
 	public void deleteById(Long id) {
 		data.removeIf(professor -> professor.getId().equals(id));
 	}

--- a/aics-domain/src/testFixtures/java/mock/FakeProfessorRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/FakeProfessorRepository.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 
 import kgu.developers.domain.professor.domain.Professor;
 import kgu.developers.domain.professor.domain.ProfessorRepository;
@@ -12,25 +13,19 @@ import kgu.developers.domain.professor.domain.ProfessorRepository;
 public class FakeProfessorRepository implements ProfessorRepository {
 
 	private final List<Professor> data = Collections.synchronizedList(new ArrayList<>());
-	private Long sequence = 1L;
+	private final AtomicLong sequence = new AtomicLong(1);
 
 	@Override
 	public Professor save(Professor professor) {
-		if (professor.getId() == null) {
-			Professor newProfessor = Professor.builder()
-				.id(sequence++)
-				.name(professor.getName())
-				.role(professor.getRole())
-				.contact(professor.getContact())
-				.email(professor.getEmail())
-				.build();
-			data.add(newProfessor);
-			return newProfessor;
-		} else {
-			deleteById(professor.getId());
-			data.add(professor);
-			return professor;
-		}
+		Professor newProfessor = Professor.builder()
+			.id(sequence.getAndIncrement())
+			.name(professor.getName())
+			.role(professor.getRole())
+			.contact(professor.getContact())
+			.email(professor.getEmail())
+			.build();
+		data.add(newProfessor);
+		return newProfessor;
 	}
 
 	@Override

--- a/aics-domain/src/testFixtures/java/mock/FakeProfessorRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/FakeProfessorRepository.java
@@ -1,0 +1,60 @@
+package mock;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import kgu.developers.domain.professor.domain.Professor;
+import kgu.developers.domain.professor.domain.ProfessorRepository;
+
+public class FakeProfessorRepository implements ProfessorRepository {
+
+	private final List<Professor> data = Collections.synchronizedList(new ArrayList<>());
+	private Long sequence = 1L;
+
+	@Override
+	public Professor save(Professor professor) {
+		if (professor.getId() == null) {
+			Professor newProfessor = Professor.builder()
+				.id(sequence++)
+				.name(professor.getName())
+				.role(professor.getRole())
+				.contact(professor.getContact())
+				.email(professor.getEmail())
+				.build();
+			data.add(newProfessor);
+			return newProfessor;
+		} else {
+			deleteById(professor.getId());
+			data.add(professor);
+			return professor;
+		}
+	}
+
+	@Override
+	public Optional<Professor> findById(Long id) {
+		return data.stream()
+			.filter(professor -> professor.getId().equals(id))
+			.findFirst();
+	}
+
+	@Override
+	public List<Professor> findAllOrderByRoleAndName() {
+		return data.stream()
+			.sorted(Comparator.comparing(Professor::getRole)
+				.thenComparing(Professor::getName))
+			.toList();
+	}
+
+	@Override
+	public void delete(Professor professor) {
+		data.removeIf(p -> p.getId().equals(professor.getId()));
+	}
+
+	// 추가: ID로 삭제하는 메서드
+	public void deleteById(Long id) {
+		data.removeIf(professor -> professor.getId().equals(id));
+	}
+}

--- a/aics-domain/src/testFixtures/java/professor/domain/ProfessorDomainTest.java
+++ b/aics-domain/src/testFixtures/java/professor/domain/ProfessorDomainTest.java
@@ -1,0 +1,34 @@
+package professor.domain;
+
+import static kgu.developers.domain.professor.domain.Role.PROFESSOR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kgu.developers.domain.professor.domain.Professor;
+import kgu.developers.domain.professor.domain.Role;
+
+public class ProfessorDomainTest {
+
+	@Test
+	@DisplayName("PROFESSOR 객체를 생성할 수 있다")
+	public void createProfessor_Success() {
+		// given
+		String name = "박민준";
+		Role role = PROFESSOR;
+		String contact = "010-1234-5678";
+		String email = "alswns11346@kgu.ac.kr";
+
+		// when
+		Professor professor = Professor.create(name, role, contact, email);
+
+		// then
+		assertNotNull(professor);
+		assertEquals(name, professor.getName());
+		assertEquals(role, professor.getRole());
+		assertEquals(contact, professor.getContact());
+		assertEquals(email, professor.getEmail());
+	}
+}

--- a/aics-domain/src/testFixtures/java/user/domain/UserDomainTest.java
+++ b/aics-domain/src/testFixtures/java/user/domain/UserDomainTest.java
@@ -22,7 +22,7 @@ public class UserDomainTest {
 		String id = "202411345";
 		String password = "password";
 		String name = "홍길동";
-		String email = "valid@kyonggi.ac.kr";
+		String email = "valid@kgu.ac.kr";
 		String phone = "010-1234-5678";
 		Major major = Major.CSE;
 


### PR DESCRIPTION
## Summary

> close #110 

**testfixtures 기반 professor testcode 구현**

## Tasks

- FakeProfessorRepository 구현 및 테스트용 데이터 추가
- ProfessorService 관련 테스트 코드 작성
- 교수 삭제 로직을 객체가 아닌 ID 기반으로 리팩토링
- 허용 가능한 이메일 도메인 검증 로직 추가 (@kyonggi.ac.kr, @kgu.ac.kr)
