### PR TITLE
feature/#127 about domain, service testcode 구현

### DIFF
--- a/aics-api/src/main/java/kgu/developers/api/about/application/AboutService.java
+++ b/aics-api/src/main/java/kgu/developers/api/about/application/AboutService.java
@@ -1,6 +1,5 @@
 package kgu.developers.api.about.application;
 
-
 import static kgu.developers.domain.about.domain.MainCategory.DEPT_INTRO;
 import static kgu.developers.domain.about.domain.MainCategory.EDU_ACTIVITIES;
 import static kgu.developers.domain.about.domain.SubCategory.CLUB_INTRO;
@@ -10,9 +9,17 @@ import static kgu.developers.domain.about.domain.SubCategory.EDU_OBJECTIVES;
 import static kgu.developers.domain.about.domain.SubCategory.HISTORY;
 import static kgu.developers.domain.about.domain.SubCategory.LEARNING_ACTIVITIES;
 
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import kgu.developers.api.about.presentation.Exception.AboutNotFoundException;
 import kgu.developers.api.about.presentation.Exception.CategoryNotMatchException;
 import kgu.developers.api.about.presentation.request.AboutRequest;
+import kgu.developers.api.about.presentation.request.AboutUpdateRequest;
 import kgu.developers.api.about.presentation.response.AboutPersistResponse;
 import kgu.developers.api.about.presentation.response.AboutResponse;
 import kgu.developers.domain.about.domain.About;
@@ -20,12 +27,6 @@ import kgu.developers.domain.about.domain.AboutRepository;
 import kgu.developers.domain.about.domain.MainCategory;
 import kgu.developers.domain.about.domain.SubCategory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.EnumMap;
-import java.util.Map;
-import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -67,7 +68,7 @@ public class AboutService {
 	}
 
 	@Transactional
-	public void updateAbout(Long id, AboutRequest request) {
+	public void updateAbout(Long id, AboutUpdateRequest request) {
 		About about = aboutRepository.findById(id)
 			.orElseThrow(AboutNotFoundException::new);
 
@@ -75,9 +76,8 @@ public class AboutService {
 	}
 
 	private void categoryMatchCheck(MainCategory mainCategory, SubCategory subCategory) {
-		if (CATEGORY_MAP.getOrDefault(mainCategory, Set.of()).contains(subCategory))
-			return;
-
-		throw new CategoryNotMatchException();
+		if (!CATEGORY_MAP.getOrDefault(mainCategory, Set.of()).contains(subCategory)) {
+			throw new CategoryNotMatchException();
+		}
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/about/presentation/AboutController.java
+++ b/aics-api/src/main/java/kgu/developers/api/about/presentation/AboutController.java
@@ -3,19 +3,6 @@ package kgu.developers.api.about.presentation;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import kgu.developers.api.about.application.AboutService;
-import kgu.developers.api.about.presentation.request.AboutRequest;
-import kgu.developers.api.about.presentation.response.AboutPersistResponse;
-import kgu.developers.api.about.presentation.response.AboutResponse;
-import kgu.developers.domain.about.domain.MainCategory;
-import kgu.developers.domain.about.domain.SubCategory;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -25,6 +12,21 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kgu.developers.api.about.application.AboutService;
+import kgu.developers.api.about.presentation.request.AboutRequest;
+import kgu.developers.api.about.presentation.request.AboutUpdateRequest;
+import kgu.developers.api.about.presentation.response.AboutPersistResponse;
+import kgu.developers.api.about.presentation.response.AboutResponse;
+import kgu.developers.domain.about.domain.MainCategory;
+import kgu.developers.domain.about.domain.SubCategory;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -69,7 +71,7 @@ public class AboutController {
 	@PatchMapping("/{id}")
 	public ResponseEntity<Void> updateAbout(
 		@PathVariable Long id,
-		@RequestBody AboutRequest request
+		@RequestBody AboutUpdateRequest request
 	) {
 		aboutService.updateAbout(id, request);
 		return ResponseEntity.status(NO_CONTENT).build();

--- a/aics-api/src/main/java/kgu/developers/api/about/presentation/request/AboutRequest.java
+++ b/aics-api/src/main/java/kgu/developers/api/about/presentation/request/AboutRequest.java
@@ -7,7 +7,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import kgu.developers.domain.about.domain.MainCategory;
 import kgu.developers.domain.about.domain.SubCategory;
+import lombok.Builder;
 
+@Builder
 public record AboutRequest(
 	@Schema(description = "메인 카테고리", example = "EDU_ACTIVITIES", requiredMode = REQUIRED)
 	@NotNull

--- a/aics-api/src/main/java/kgu/developers/api/about/presentation/request/AboutUpdateRequest.java
+++ b/aics-api/src/main/java/kgu/developers/api/about/presentation/request/AboutUpdateRequest.java
@@ -1,0 +1,15 @@
+package kgu.developers.api.about.presentation.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record AboutUpdateRequest(
+	@Schema(description = "페이지 내용(JSON 형식)", example = "{key:value}", requiredMode = REQUIRED)
+	@NotNull
+	String content
+) {
+}

--- a/aics-api/src/testFixtures/java/about/application/AboutServiceTest.java
+++ b/aics-api/src/testFixtures/java/about/application/AboutServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import kgu.developers.api.about.application.AboutService;
+import kgu.developers.api.about.presentation.Exception.AboutNotFoundException;
 import kgu.developers.api.about.presentation.Exception.CategoryNotMatchException;
 import kgu.developers.api.about.presentation.request.AboutRequest;
 import kgu.developers.api.about.presentation.request.AboutUpdateRequest;
@@ -47,7 +48,7 @@ public class AboutServiceTest {
 		String detail = "detail";
 		String content = "content";
 
-		AboutRequest aboutRequest = AboutRequest.builder()
+		AboutRequest request = AboutRequest.builder()
 			.main(main)
 			.sub(sub)
 			.detail(detail)
@@ -55,7 +56,7 @@ public class AboutServiceTest {
 			.build();
 
 		// when
-		AboutPersistResponse response = aboutService.createAbout(aboutRequest);
+		AboutPersistResponse response = aboutService.createAbout(request);
 
 		// then
 		AboutResponse aboutResponse = aboutService.getAbout(main, sub, detail);
@@ -65,13 +66,13 @@ public class AboutServiceTest {
 	}
 
 	@Test
-	@DisplayName("createAbout은 메인 카테고리와 서브 카테고리의 관계가 올바르지 않을 시 CategoryNotMatchException을 발생 한다.")
+	@DisplayName("createAbout은 메인 카테고리와 서브 카테고리의 관계가 올바르지 않은 생성 요청 시 CategoryNotMatchException을 발생 한다.")
 	public void createAbout_CategoryNotMatch_ThrowsException() {
 		// given
 		MainCategory main = DEPT_INTRO;
 		SubCategory sub = CURRICULUM;
-		String detail = "failDetail";
-		String content = "failContent";
+		String detail = "detail";
+		String content = "content";
 
 		AboutRequest request = AboutRequest.builder()
 			.main(main)
@@ -103,6 +104,40 @@ public class AboutServiceTest {
 	}
 
 	@Test
+	@DisplayName("getAbout은 메인 카테고리와 서브 카테고리의 관계가 올바르지 않을 시 CategoryNotMatchException을 발생 한다.")
+	public void getAbout_CategoryNotMatch_ThrowsException() {
+		// given
+		MainCategory main = DEPT_INTRO;
+		SubCategory sub = CURRICULUM;
+		String detail = "failDetail";
+
+		// when
+		// then
+		assertThatThrownBy(() -> {
+			aboutService.getAbout(main, sub, detail);
+		}).isInstanceOf(CategoryNotMatchException.class);
+	}
+
+	@Test
+	@DisplayName("getAbout은 존재하지 않는 카테고리로 조회 시 AboutNotMatchException을 발생 한다.")
+	public void getAbout_AboutNotMatch_ThrowsException() {
+		// given
+		MainCategory main = DEPT_INTRO;
+		SubCategory sub = HISTORY;
+		String detail = "failDetail";
+
+		// when
+		// then
+		assertThatThrownBy(() -> {
+			aboutService.getAbout(main, sub, null);
+		}).isInstanceOf(AboutNotFoundException.class);
+
+		assertThatThrownBy(() -> {
+			aboutService.getAbout(main, sub, detail);
+		}).isInstanceOf(AboutNotFoundException.class);
+	}
+
+	@Test
 	@DisplayName("updateAbout은 About의 content를 수정할 수 있다.")
 	public void updateAbout_Success() {
 		// given
@@ -119,5 +154,22 @@ public class AboutServiceTest {
 		AboutResponse response = aboutService.getAbout(EDU_ACTIVITIES, CURRICULUM, "initDetail");
 
 		assertEquals(response.content(), "updateContent");
+	}
+
+	@Test
+	@DisplayName("updateAbout은 About의 content를 수정할 수 있다.")
+	public void updateAbout_AboutNotFound_ThrowsException() {
+		// given
+		Long id = 0L;
+
+		AboutUpdateRequest request = AboutUpdateRequest.builder()
+			.content("updateContent")
+			.build();
+
+		// when
+		// then
+		assertThatThrownBy(() -> {
+			aboutService.updateAbout(id, request);
+		}).isInstanceOf(AboutNotFoundException.class);
 	}
 }

--- a/aics-api/src/testFixtures/java/about/application/AboutServiceTest.java
+++ b/aics-api/src/testFixtures/java/about/application/AboutServiceTest.java
@@ -119,8 +119,8 @@ public class AboutServiceTest {
 	}
 
 	@Test
-	@DisplayName("getAbout은 존재하지 않는 카테고리로 조회 시 AboutNotMatchException을 발생 한다.")
-	public void getAbout_AboutNotMatch_ThrowsException() {
+	@DisplayName("getAbout은 존재하지 않는 카테고리로 조회 시 AboutNotFoundException을 발생 한다.")
+	public void getAbout_AboutNotFound_ThrowsException() {
 		// given
 		MainCategory main = DEPT_INTRO;
 		SubCategory sub = HISTORY;
@@ -157,7 +157,7 @@ public class AboutServiceTest {
 	}
 
 	@Test
-	@DisplayName("updateAbout은 About의 content를 수정할 수 있다.")
+	@DisplayName("updateAbout은 존재하지 않는 id로 수정 요청 시 AboutNotFoundException을 발생 한다.")
 	public void updateAbout_AboutNotFound_ThrowsException() {
 		// given
 		Long id = 0L;

--- a/aics-api/src/testFixtures/java/about/application/AboutServiceTest.java
+++ b/aics-api/src/testFixtures/java/about/application/AboutServiceTest.java
@@ -1,0 +1,123 @@
+package about.application;
+
+import static kgu.developers.domain.about.domain.MainCategory.DEPT_INTRO;
+import static kgu.developers.domain.about.domain.MainCategory.EDU_ACTIVITIES;
+import static kgu.developers.domain.about.domain.SubCategory.CURRICULUM;
+import static kgu.developers.domain.about.domain.SubCategory.HISTORY;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kgu.developers.api.about.application.AboutService;
+import kgu.developers.api.about.presentation.Exception.CategoryNotMatchException;
+import kgu.developers.api.about.presentation.request.AboutRequest;
+import kgu.developers.api.about.presentation.request.AboutUpdateRequest;
+import kgu.developers.api.about.presentation.response.AboutPersistResponse;
+import kgu.developers.api.about.presentation.response.AboutResponse;
+import kgu.developers.domain.about.domain.About;
+import kgu.developers.domain.about.domain.MainCategory;
+import kgu.developers.domain.about.domain.SubCategory;
+import mock.FakeAboutRepository;
+
+public class AboutServiceTest {
+	private AboutService aboutService;
+
+	@BeforeEach
+	public void init() {
+		FakeAboutRepository fakeAboutRepository = new FakeAboutRepository();
+		this.aboutService = new AboutService(fakeAboutRepository);
+
+		fakeAboutRepository.save(About.builder()
+			.mainCategory(EDU_ACTIVITIES)
+			.subCategory(CURRICULUM)
+			.detailCategory("initDetail")
+			.content("initContent")
+			.build());
+	}
+
+	@Test
+	@DisplayName("createAbout은 about을 생성할 수 있다.")
+	public void createAbout_Success() {
+		// given
+		MainCategory main = DEPT_INTRO;
+		SubCategory sub = HISTORY;
+		String detail = "detail";
+		String content = "content";
+
+		AboutRequest aboutRequest = AboutRequest.builder()
+			.main(main)
+			.sub(sub)
+			.detail(detail)
+			.content(content)
+			.build();
+
+		// when
+		AboutPersistResponse response = aboutService.createAbout(aboutRequest);
+
+		// then
+		AboutResponse aboutResponse = aboutService.getAbout(main, sub, detail);
+
+		assertEquals(response.id(), 2L);
+		assertEquals(aboutResponse.content(), content);
+	}
+
+	@Test
+	@DisplayName("createAbout은 메인 카테고리와 서브 카테고리의 관계가 올바르지 않을 시 CategoryNotMatchException을 발생 한다.")
+	public void createAbout_CategoryNotMatch_ThrowsException() {
+		// given
+		MainCategory main = DEPT_INTRO;
+		SubCategory sub = CURRICULUM;
+		String detail = "failDetail";
+		String content = "failContent";
+
+		AboutRequest request = AboutRequest.builder()
+			.main(main)
+			.sub(sub)
+			.detail(detail)
+			.content(content)
+			.build();
+
+		// when
+		// then
+		assertThatThrownBy(() -> {
+			aboutService.createAbout(request);
+		}).isInstanceOf(CategoryNotMatchException.class);
+	}
+
+	@Test
+	@DisplayName("getAbout은 About을 조회할 수 있다.")
+	public void getAbout_Success() {
+		// given
+		MainCategory main = EDU_ACTIVITIES;
+		SubCategory sub = CURRICULUM;
+		String detail = "initDetail";
+
+		// when
+		AboutResponse aboutResponse = aboutService.getAbout(main, sub, detail);
+
+		// then
+		assertEquals(aboutResponse.content(), "initContent");
+	}
+
+	@Test
+	@DisplayName("updateAbout은 About의 content를 수정할 수 있다.")
+	public void updateAbout_Success() {
+		// given
+		Long id = 1L;
+
+		AboutUpdateRequest request = AboutUpdateRequest.builder()
+			.content("updateContent")
+			.build();
+
+		// when
+		aboutService.updateAbout(id, request);
+
+		// then
+		AboutResponse response = aboutService.getAbout(EDU_ACTIVITIES, CURRICULUM, "initDetail");
+
+		assertEquals(response.content(), "updateContent");
+	}
+}

--- a/aics-domain/src/testFixtures/java/about/application/AboutServiceTest.java
+++ b/aics-domain/src/testFixtures/java/about/application/AboutServiceTest.java
@@ -1,0 +1,4 @@
+package about.application;
+
+public class AboutServiceTest {
+}

--- a/aics-domain/src/testFixtures/java/about/domain/AboutDomainTest.java
+++ b/aics-domain/src/testFixtures/java/about/domain/AboutDomainTest.java
@@ -1,0 +1,50 @@
+package about.domain;
+
+import static kgu.developers.domain.about.domain.MainCategory.DEPT_INTRO;
+import static kgu.developers.domain.about.domain.SubCategory.HISTORY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kgu.developers.domain.about.domain.About;
+import kgu.developers.domain.about.domain.MainCategory;
+import kgu.developers.domain.about.domain.SubCategory;
+
+public class AboutDomainTest {
+	@Test
+	@DisplayName("ABOUT 객체를 생성할 수 있다.")
+	public void createAbout_Success() {
+		// given
+		MainCategory mainCategory = DEPT_INTRO;
+		SubCategory subCategory = HISTORY;
+		String detailCategory = "test";
+		String content = "testContent";
+
+		// when
+		About about = About.create(mainCategory, subCategory, detailCategory, content);
+
+		// then
+		assertEquals(about.getMainCategory(), mainCategory);
+		assertEquals(about.getSubCategory(), subCategory);
+		assertEquals(about.getDetailCategory(), detailCategory);
+		assertEquals(about.getContent(), content);
+	}
+
+	@Test
+	@DisplayName("UpdateContent는 About 객체의 content를 수정할 수 있다.")
+	public void updateContent_Success() {
+		// given
+		String detailCategory = "test";
+		String content = "testContent";
+		About about = About.create(DEPT_INTRO, HISTORY, detailCategory, content);
+
+		String updateContent = "updateContent";
+
+		// when
+		about.updateContent(updateContent);
+
+		// then
+		assertEquals(about.getContent(), updateContent);
+	}
+}

--- a/aics-domain/src/testFixtures/java/mock/FakeAboutRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/FakeAboutRepository.java
@@ -1,0 +1,58 @@
+package mock;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import kgu.developers.domain.about.domain.About;
+import kgu.developers.domain.about.domain.AboutRepository;
+import kgu.developers.domain.about.domain.MainCategory;
+import kgu.developers.domain.about.domain.SubCategory;
+
+public class FakeAboutRepository implements AboutRepository {
+	private final List<About> data = Collections.synchronizedList(new ArrayList<>());
+	private final AtomicLong sequence = new AtomicLong(1);
+
+	@Override
+	public About save(About about) {
+		About newAbout = About.builder()
+			.id(sequence.getAndIncrement())
+			.mainCategory(about.getMainCategory())
+			.subCategory(about.getSubCategory())
+			.detailCategory(about.getDetailCategory())
+			.content(about.getContent())
+			.build();
+
+		TestEntityUtils.setCreatedAt(newAbout, LocalDateTime.now());
+
+		data.add(newAbout);
+		return newAbout;
+	}
+
+	@Override
+	public Optional<About> findByMainAndSubAndDetail(MainCategory main, SubCategory sub, String detail) {
+		return data.stream()
+			.filter(about -> about.getMainCategory().equals(main)
+				&& about.getSubCategory().equals(sub)
+				&& about.getDetailCategory().equals(detail))
+			.findFirst();
+	}
+
+	@Override
+	public Optional<About> findByMainAndSub(MainCategory main, SubCategory sub) {
+		return data.stream()
+			.filter(about -> about.getMainCategory().equals(main)
+				&& about.getSubCategory().equals(sub))
+			.findFirst();
+	}
+
+	@Override
+	public Optional<About> findById(Long id) {
+		return data.stream()
+			.filter(about -> about.getId().equals(id))
+			.findFirst();
+	}
+}


### PR DESCRIPTION
## Summary

> close #127 

## Tasks

- AboutDomainTest 구현
- AboutServiceTest 구현
- FakeAboutRepository 구현
- 수정 요정 객체 AboutRequest -> AboutUpdateRequest 수정
- 카테고리 체크 메소드 최적화

## To Reviewer

- 1. `categoryMatchCheck` 메서드 수정
 기존 코드의 불필요한 `return`을 제거하고 조건문을 간결하게 변경하여 가독성과 명확성을 높였습니다. 조건이 맞지 않을 경우 바로 예외를 던지는 구조로 개선하였습니다.


- 2. `updateAbout` 메서드 수정
수정 작업에는 content 필드만 필요하므로, 불필요한 데이터를 포함한 AboutRequest 대신 AboutUpdateRequest를 사용하도록 변경하였습니다. 또한, 생성(createAbout)과 수정(updateAbout)의 목적에 따라 요청 객체를 분리하여, 필요한 데이터만 포함하도록 설계함으로써 API의 명확성을 높이고 유지보수성을 강화했습니다.
