### PR TITLE
fix/#145 서버 에러 로그 남지 않는 문제 픽스

### DIFF
--- a/aics-api/src/main/java/kgu/developers/api/aspect/ServerErrorLoggingAspect.java
+++ b/aics-api/src/main/java/kgu/developers/api/aspect/ServerErrorLoggingAspect.java
@@ -7,7 +7,6 @@ import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import kgu.developers.common.exception.CustomException;
@@ -17,26 +16,26 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Aspect
 @Component
-@Profile({"dev", "prod"})
 public class ServerErrorLoggingAspect {
+
 	@Pointcut("execution(public * kgu.developers..*(..)) && "
-		+ "!execution(* kgu.developers.api..application..*(..)) && "
-		+ "!execution(* kgu.developers.common..*(..)) && "
-		+ "!@annotation(kgu.developers.globalutils.annotation.NoLogging) && "
+		+ "!execution(* kgu.developers.api..presentation..*(..)) && "
 		+ "!@annotation(org.springframework.boot.context.properties.ConfigurationProperties)"
 	)
 	private void logPointcut() {
 	}
 
 	@AfterThrowing(value = "logPointcut()", throwing = "exception")
-	public void logAfterThrowing(JoinPoint joinPoint, CustomException exception) {
+	public void logAfterThrowing(JoinPoint joinPoint, Exception exception) {
 		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
 		String className = signature.getDeclaringType().getSimpleName();
 
 		List<String> arguments = LoggingUtils.getArguments(joinPoint);
 		String parameterMessage = LoggingUtils.getParameterMessage(arguments);
 
-		log.error("[ERROR] POINT : {} || EXCEPTION : {} || ARGUMENTS : {}", className, exception.getCode().getCode(),
-			parameterMessage);
+		log.error("[SERVER ERROR] POINT : {} || ARGUMENTS : {}", className, parameterMessage);
+		log.error("[SERVER ERROR] MESSAGE : {}", exception.getMessage());
+		log.error("[SERVER ERROR] CAUSE : {}", exception.getCause().toString());
+		log.error("[SERVER ERROR] FINAL POINT : {}", exception.getStackTrace()[0]);
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/aspect/ServerErrorLoggingAspect.java
+++ b/aics-api/src/main/java/kgu/developers/api/aspect/ServerErrorLoggingAspect.java
@@ -36,7 +36,14 @@ public class ServerErrorLoggingAspect {
 
 		log.error("[SERVER ERROR] POINT : {} || ARGUMENTS : {}", className, parameterMessage);
 		log.error("[SERVER ERROR] MESSAGE : {}", exception.getMessage());
-		log.error("[SERVER ERROR] CAUSE : {}", exception.getCause().toString());
-		log.error("[SERVER ERROR] FINAL POINT : {}", exception.getStackTrace()[0]);
+		Throwable cause = exception.getCause();
+		StackTraceElement[] stackTrace = exception.getStackTrace();
+
+		log.error("[SERVER ERROR] CAUSE : {}",
+		    cause != null ? cause.toString() : "No cause available"
+		);
+		log.error("[SERVER ERROR] FINAL POINT : {}",
+		    (stackTrace != null && stackTrace.length > 0) ? stackTrace[0] : "No stack trace available"
+		);
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/aspect/ServerErrorLoggingAspect.java
+++ b/aics-api/src/main/java/kgu/developers/api/aspect/ServerErrorLoggingAspect.java
@@ -27,6 +27,7 @@ public class ServerErrorLoggingAspect {
 
 	@AfterThrowing(value = "logPointcut()", throwing = "exception")
 	public void logAfterThrowing(JoinPoint joinPoint, Exception exception) {
+		if (exception instanceof CustomException) return;
 		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
 		String className = signature.getDeclaringType().getSimpleName();
 

--- a/aics-common/src/main/java/kgu/developers/common/interceptor/LoggingInterceptor.java
+++ b/aics-common/src/main/java/kgu/developers/common/interceptor/LoggingInterceptor.java
@@ -35,7 +35,6 @@ public class LoggingInterceptor implements HandlerInterceptor {
 		if (handler instanceof HandlerMethod) {
 			HandlerMethod handlerMethod = (HandlerMethod)handler;
 			Method method = handlerMethod.getMethod();
-
 			return method.isAnnotationPresent(NoLogging.class);
 		}
 		return false;


### PR DESCRIPTION
## Summary

>- close #145 

SERVER ERROR 로그가 남지 않는 문제를 픽스하였습니다.

## Tasks

- 로그가 남지 않는 문제 픽스
- 서버 에러 로그  상세화

## To Reviewer

**`SERVER ERROR` 프로파일 설정 삭제**
기존에는 `SERVER ERROR`가 dev 또는 prod 환경에서만 로그가 찍혔지만, local 환경에서 원활한 작업을 위해 해당 프로파일 설정 어노테이션을 제거하였습니다.

**AOP pointcut 수정**
`!execution` 조건을 application에서 presentation으로 변경하였습니다. 서버 에러 발생 시 파라미터 값을 로그에 남기도록 설정했으나, Controller 레벨에서는 요청 본문 전체를 매핑하는 객체가 파라미터로 전달되어 로그가 중첩된 JSON 형태의 복잡한 구조로 출력되는 문제가 있었습니다. 이를 개선하기 위해 Service 레벨에서 전달되는 순수한 파라미터를 로그에 남길 수 있도록 Pointcut을 수정하였습니다.

**`SERVER ERROR` cause와 final point 로그 작성**
서버 에러의 발생 이유와 발생 지점을 기록하기 위해 해당 로그를 추가하였습니다.

## Screenshot
<img width="1901" alt="스크린샷 2024-12-25 오전 12 02 29" src="https://github.com/user-attachments/assets/81dd34c8-ffc7-48a3-aa57-97f18b17aa08" />

