### PR TITLE
refactor/#132 확장자 검증 로직 추가 및 파일 업로드 관련 수정

### DIFF
--- a/aics-api/src/main/java/kgu/developers/api/file/application/FileService.java
+++ b/aics-api/src/main/java/kgu/developers/api/file/application/FileService.java
@@ -19,11 +19,10 @@ public class FileService {
 
 	public FilePathResponse saveFile(MultipartFile file, FileDomain fileDomain, Long directoryId) {
 		String storedPath = fileStorageService.store(file, fileDomain, directoryId);
-		String encryptedPath = AesUtil.encrypt(storedPath);
-		FileEntity fileEntity = FileEntity.create(file.getOriginalFilename(), encryptedPath, file.getSize(),
+		FileEntity fileEntity = FileEntity.create(file.getOriginalFilename(), storedPath, file.getSize(),
 			file.getContentType());
 		FileEntity savedFile = fileRepository.save(fileEntity);
-		return FilePathResponse.of(savedFile.getId(), AesUtil.decrypt(savedFile.getPhysicalPath()));
+		return FilePathResponse.of(savedFile);
 	}
 
 }

--- a/aics-api/src/main/java/kgu/developers/api/file/application/FileService.java
+++ b/aics-api/src/main/java/kgu/developers/api/file/application/FileService.java
@@ -22,7 +22,7 @@ public class FileService {
 		FileEntity fileEntity = FileEntity.create(file.getOriginalFilename(), storedPath, file.getSize(),
 			file.getContentType());
 		FileEntity savedFile = fileRepository.save(fileEntity);
-		return FilePathResponse.of(savedFile);
+		return FilePathResponse.from(savedFile);
 	}
 
 }

--- a/aics-api/src/main/java/kgu/developers/api/file/presentation/response/FilePathResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/file/presentation/response/FilePathResponse.java
@@ -15,7 +15,7 @@ public record FilePathResponse(
 	@Schema(description = "파일 경로", example = "/files/2025-curriculum", requiredMode = REQUIRED)
 	String physicalPath
 ) {
-	public static FilePathResponse of(FileEntity fileEntity) {
+	public static FilePathResponse from(FileEntity fileEntity) {
 		String decryptedPath = AesUtil.decrypt(fileEntity.getPhysicalPath());
 		return FilePathResponse.builder()
 			.id(fileEntity.getId())

--- a/aics-api/src/main/java/kgu/developers/api/file/presentation/response/FilePathResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/file/presentation/response/FilePathResponse.java
@@ -3,6 +3,8 @@ package kgu.developers.api.file.presentation.response;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import kgu.developers.domain.file.domain.FileEntity;
+import kgu.developers.globalutils.encryption.AesUtil;
 import lombok.Builder;
 
 @Builder
@@ -13,9 +15,10 @@ public record FilePathResponse(
 	@Schema(description = "파일 경로", example = "/files/2025-curriculum", requiredMode = REQUIRED)
 	String physicalPath
 ) {
-	public static FilePathResponse of(Long id, String decryptedPath) {
+	public static FilePathResponse of(FileEntity fileEntity) {
+		String decryptedPath = AesUtil.decrypt(fileEntity.getPhysicalPath());
 		return FilePathResponse.builder()
-			.id(id)
+			.id(fileEntity.getId())
 			.physicalPath(decryptedPath)
 			.build();
 	}

--- a/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostDetailResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostDetailResponse.java
@@ -77,7 +77,7 @@ public record PostDetailResponse(
 			.views(post.getViews())
 			.isPinned(post.isPinned())
 			.file(post.getFile() != null ?
-				FilePathResponse.of(post.getFile()) : null)
+				FilePathResponse.from(post.getFile()) : null)
 			.createdAt(post.getCreatedAt().format(formatter))
 			.prevPost(prevPost)
 			.nextPost(nextPost)

--- a/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostDetailResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostDetailResponse.java
@@ -77,7 +77,7 @@ public record PostDetailResponse(
 			.views(post.getViews())
 			.isPinned(post.isPinned())
 			.file(post.getFile() != null ?
-				FilePathResponse.of(post.getFile().getId(), AesUtil.decrypt(post.getFile().getPhysicalPath())) : null)
+				FilePathResponse.of(post.getFile()) : null)
 			.createdAt(post.getCreatedAt().format(formatter))
 			.prevPost(prevPost)
 			.nextPost(nextPost)

--- a/aics-api/src/main/resources/application.yml
+++ b/aics-api/src/main/resources/application.yml
@@ -34,8 +34,7 @@ file:
    url: /cloud
    upload-path: ${user.dir}/cloud
    secret-key: ${FILE_SECRET_KEY}
-   disallow-extension: .exe, .bat, .sh, .cmd, .js, .html, .jsp, .php, .asp, .aspx, .dll, .so
-   allow-extension: .jpg, .jpeg, .png, .gif, .pdf, .doc, .docx, .xls, .xlsx, .ppt, .pptx, .txt, .csv, .zip, .rar
+   disallowed-extensions: .exe, .bat, .sh, .cmd, .js, .html, .jsp, .php, .asp, .aspx, .dll, .so
 
 springdoc:
   default-consumes-media-type: application/json

--- a/aics-api/src/main/resources/application.yml
+++ b/aics-api/src/main/resources/application.yml
@@ -34,7 +34,7 @@ file:
    url: /cloud
    upload-path: ${user.dir}/cloud
    secret-key: ${FILE_SECRET_KEY}
-   disallowed-extensions: .exe, .bat, .sh, .cmd, .js, .html, .jsp, .php, .asp, .aspx, .dll, .so
+   disallowed-extensions: exe, bat, sh, cmd, js, html, jsp, php, asp, aspx, dll, so
 
 springdoc:
   default-consumes-media-type: application/json

--- a/aics-api/src/main/resources/application.yml
+++ b/aics-api/src/main/resources/application.yml
@@ -34,7 +34,7 @@ file:
    url: /cloud
    upload-path: ${user.dir}/cloud
    secret-key: ${FILE_SECRET_KEY}
-   disallowed-extensions: exe, bat, sh, cmd, js, html, jsp, php, asp, aspx, dll, so
+   disallowed-extensions: exe, bat, sh, cmd, js, html, jsp, php, asp, aspx, dll, so, ps1, vbs, msi, htaccess, phtml, jar, war
 
 springdoc:
   default-consumes-media-type: application/json

--- a/aics-common/src/main/java/kgu/developers/common/config/SecurityConfig.java
+++ b/aics-common/src/main/java/kgu/developers/common/config/SecurityConfig.java
@@ -59,7 +59,8 @@ public class SecurityConfig {
 	private static final String[] STATIC_RESOURCES_PATTERNS = {
 		"/img/**",
 		"/css/**",
-		"/js/**"
+		"/js/**",
+		"/cloud/**",
 	};
 
 	private static final String[] PERMIT_ALL_PATTERNS = {
@@ -73,7 +74,7 @@ public class SecurityConfig {
 		"/api/v1/users/signup",
 		"/api/v1/auth/**",
 		"/api/v1/professors",
-		"/api/v1/abouts"
+		"/api/v1/abouts",
 	};
 
 	CorsConfigurationSource corsConfigurationSource() {

--- a/aics-domain/src/main/java/kgu/developers/domain/file/domain/FileEntity.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/domain/FileEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import kgu.developers.common.domain.BaseTimeEntity;
+import kgu.developers.globalutils.encryption.AesUtil;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,9 +37,11 @@ public class FileEntity extends BaseTimeEntity {
 	private String extension;
 
 	public static FileEntity create(String logicalName, String physicalPath, Long fileSize, String extension) {
+		String encryptedLogicalName = AesUtil.encrypt(logicalName);
+		String encryptedPhysicalPath = AesUtil.encrypt(physicalPath);
 		return FileEntity.builder()
-			.logicalName(logicalName)
-			.physicalPath(physicalPath)
+			.logicalName(encryptedLogicalName)
+			.physicalPath(encryptedPhysicalPath)
 			.fileSize(fileSize)
 			.extension(extension)
 			.build();

--- a/aics-domain/src/main/java/kgu/developers/domain/file/domain/FileEntity.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/domain/FileEntity.java
@@ -31,19 +31,31 @@ public class FileEntity extends BaseTimeEntity {
 	private String physicalPath;
 
 	@Column(nullable = false)
-	private Long fileSize;
+	private String fileSize;
 
 	@Column(nullable = false)
 	private String extension;
 
+	private static final long KB = 1024L;
+	private static final long MB = KB * 1024;
+	private static final long GB = MB * 1024;
+
 	public static FileEntity create(String logicalName, String physicalPath, Long fileSize, String extension) {
+		String readableFileSize = convertToReadableFileSize(fileSize);
 		String encryptedLogicalName = AesUtil.encrypt(logicalName);
 		String encryptedPhysicalPath = AesUtil.encrypt(physicalPath);
 		return FileEntity.builder()
 			.logicalName(encryptedLogicalName)
 			.physicalPath(encryptedPhysicalPath)
-			.fileSize(fileSize)
+			.fileSize(readableFileSize)
 			.extension(extension)
 			.build();
+	}
+
+	private static String convertToReadableFileSize(long sizeInBytes) {
+		if (sizeInBytes < KB) return sizeInBytes + " Bytes";
+		else if (sizeInBytes < MB) return String.format("%.2f KB", sizeInBytes / (double) KB);
+		else if (sizeInBytes < GB) return String.format("%.2f MB", sizeInBytes / (double) MB);
+		else return String.format("%.2f GB", sizeInBytes / (double) GB);
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/file/exception/FileDomainExceptionCode.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/exception/FileDomainExceptionCode.java
@@ -14,6 +14,7 @@ public enum FileDomainExceptionCode implements ExceptionCode {
 	FILE_DIRECTORY_CREATION_FAILED(BAD_REQUEST, "파일 디렉토리 생성에 실패하였습니다."),
 	FILE_STORE_FAILED(BAD_REQUEST, "파일 저장에 실패하였습니다."),
 	FILE_PATH_INVALID(BAD_REQUEST, "파일 경로가 올바르지 않습니다."),
+	NOT_SUPPORTED_FILE_EXTENSION(BAD_REQUEST, "지원하지 않는 파일 확장자입니다."),
 	FILE_NOT_FOUND(NOT_FOUND, "파일을 찾을 수 없습니다.")
 	;
 

--- a/aics-domain/src/main/java/kgu/developers/domain/file/exception/NotSupportedFileExtensionException.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/exception/NotSupportedFileExtensionException.java
@@ -1,0 +1,11 @@
+package kgu.developers.domain.file.exception;
+
+import static kgu.developers.domain.file.exception.FileDomainExceptionCode.*;
+
+import kgu.developers.common.exception.CustomException;
+
+public class NotSupportedFileExtensionException extends CustomException {
+	public NotSupportedFileExtensionException() {
+		super(NOT_SUPPORTED_FILE_EXTENSION);
+	}
+}

--- a/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/FilePathProperties.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/FilePathProperties.java
@@ -1,5 +1,7 @@
 package kgu.developers.domain.file.infrastructure;
 
+import java.util.Set;
+
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -12,5 +14,6 @@ import org.springframework.context.annotation.Configuration;
 public class FilePathProperties {
     private String url;
     private String uploadPath;
+    private Set<String> disallowedExtensions;
 }
 

--- a/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/FileStorageServiceImpl.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/FileStorageServiceImpl.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
@@ -21,17 +22,20 @@ import kgu.developers.domain.file.exception.FileDirectoryCreationFailedException
 import kgu.developers.domain.file.exception.FileNotFoundException;
 import kgu.developers.domain.file.exception.FilePathInvalidException;
 import kgu.developers.domain.file.exception.FileStoreFailedException;
+import kgu.developers.domain.file.exception.NotSupportedFileExtensionException;
 
 @Service
 public class FileStorageServiceImpl implements FileStorageService {
     private final Path rootLocation;
     private final String url;
+    private final Set<String> disallowedExtensions;
 
     @Autowired
     public FileStorageServiceImpl(FilePathProperties filePathProperties) {
         this.rootLocation = Paths.get(filePathProperties.getUploadPath())
                 .toAbsolutePath().normalize();
         this.url = filePathProperties.getUrl();
+        this.disallowedExtensions = filePathProperties.getDisallowedExtensions();
         try {
             Files.createDirectories(this.rootLocation);
         } catch (Exception e) {
@@ -44,7 +48,7 @@ public class FileStorageServiceImpl implements FileStorageService {
         String fileName = StringUtils.cleanPath(Objects.requireNonNull(file.getOriginalFilename()));
         String path = getFullPath(fileDomain, directoryId, fileName);
         try {
-            validateInvalidPath(path);
+            validateAttributes(path, fileName);
             Path targetLocation = this.rootLocation.resolve(path);
             Files.copy(file.getInputStream(), targetLocation, REPLACE_EXISTING);
             String relativePath = this.rootLocation.relativize(targetLocation).toString();
@@ -69,6 +73,16 @@ public class FileStorageServiceImpl implements FileStorageService {
     @Override
     public void deleteAll() {
 
+    }
+
+    private void validateAttributes(String path, String fileName) {
+        validateInvalidPath(path);
+        validateExtension(fileName, disallowedExtensions);
+    }
+
+    private void validateExtension(String originalFileName, Set<String> disallowedExtensions) {
+        String extension = StringUtils.getFilenameExtension(originalFileName);
+        if (disallowedExtensions.contains(extension)) throw new NotSupportedFileExtensionException();
     }
 
     private String getFullPath(FileDomain fileDomain, Long directoryId, String fileName) {

--- a/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/FileStorageServiceImpl.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/FileStorageServiceImpl.java
@@ -81,7 +81,7 @@ public class FileStorageServiceImpl implements FileStorageService {
     }
 
     private void validateExtension(String originalFileName, Set<String> disallowedExtensions) {
-        if (originalFileName.lastIndexOf('.') <= 0 || disallowedExtensions.contains(extension)) throw new NotSupportedFileExtensionException();
+        String extension = originalFileName.substring(originalFileName.lastIndexOf('.') + 1).toLowerCase();
         if (disallowedExtensions.contains(extension)) throw new NotSupportedFileExtensionException();
     }
 

--- a/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/FileStorageServiceImpl.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/FileStorageServiceImpl.java
@@ -81,7 +81,7 @@ public class FileStorageServiceImpl implements FileStorageService {
     }
 
     private void validateExtension(String originalFileName, Set<String> disallowedExtensions) {
-        String extension = originalFileName.substring(originalFileName.lastIndexOf('.') + 1).toLowerCase();
+        if (originalFileName.lastIndexOf('.') <= 0 || disallowedExtensions.contains(extension)) throw new NotSupportedFileExtensionException();
         if (disallowedExtensions.contains(extension)) throw new NotSupportedFileExtensionException();
     }
 

--- a/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/FileStorageServiceImpl.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/FileStorageServiceImpl.java
@@ -47,8 +47,8 @@ public class FileStorageServiceImpl implements FileStorageService {
     public String store(MultipartFile file, FileDomain fileDomain, Long directoryId) {
         String fileName = StringUtils.cleanPath(Objects.requireNonNull(file.getOriginalFilename()));
         String path = getFullPath(fileDomain, directoryId, fileName);
+        validateAttributes(path, fileName);
         try {
-            validateAttributes(path, fileName);
             Path targetLocation = this.rootLocation.resolve(path);
             Files.copy(file.getInputStream(), targetLocation, REPLACE_EXISTING);
             String relativePath = this.rootLocation.relativize(targetLocation).toString();
@@ -81,7 +81,7 @@ public class FileStorageServiceImpl implements FileStorageService {
     }
 
     private void validateExtension(String originalFileName, Set<String> disallowedExtensions) {
-        String extension = StringUtils.getFilenameExtension(originalFileName);
+        String extension = originalFileName.substring(originalFileName.lastIndexOf('.') + 1).toLowerCase();
         if (disallowedExtensions.contains(extension)) throw new NotSupportedFileExtensionException();
     }
 


### PR DESCRIPTION
## Summary

>- closed #132 

파일 업로드 시 허용되지 않는 확장자를 검증하는 로직을 추가하였습니다. 또한 파일의 logicalName을 암호화 저장하고 파일 size를 String으로 변환하여 저장하는 등 몇가지 주요 로직을 변경하였습니다.

## Tasks

- 허용되지 않는 확장자 검증
- `logicalName` 필드를 암호화하여 데이터베이스에 저장하도록 변경
- 파일 크기를 Bytes, KB, MB, GB으로 변환하여 저장하는 도메인 규칙 추가

## To Reviewer

**허용되지 않는 확장자 검증**
기존에는 `application.yml`에서 `disallowed-extensions`와 함께 `allowed-extensions`도 설정되어 있었습니다. 하지만 허용되지 않는 확장자만 검증하면 충분하다고 판단하여 `allowed-extensions` 설정을 제거했습니다. 만약 특정 확장자만 허용할 경우, 서버가 예상하지 못한 안전한 파일조차 사용자가 업로드할 수 없게 되는 상황을 방지하기 위해 그렇게 조처를 취하였습니다.

**`logicalName` 암호화 저장**
파일의 원본 이름인 `logicalName`을 암호화하여 저장합니다. 보안성을 강화하는 동시에, 동일한 파일 이름의 파일이 업로드될 경우 기존 파일이 덮어씌워지는 문제를 방지하기 위함입니다.

**파일 사이즈 변환 도메인 규칙 추가**
파일 사이즈를 그대로 저장하는 대신, KB, MB, GB 등의 사람이 읽기 쉬운 형식으로 변환하여 저장합니다. 이렇게 하여 클라이언트에서 별도로 변환 로직을 처리해야 하는 불편함을 해소하고자 합니다.

**파일 및 이미지 리사이징**
파일 및 이미지 리사이징 로직은 추후 구현할 예정입니다.

