### PR TITLE
fix/#168 개발 서버 Swagger에서 ip가 표기되지 않는 버그 픽스

### DIFF
--- a/aics-admin/src/main/java/kgu/developers/admin/config/SwaggerConfig.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package kgu.developers.admin.config;
 import static java.lang.String.format;
 import static org.springframework.security.config.Elements.JWT;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -93,6 +94,7 @@ public class SwaggerConfig {
 	}
 
 	private String getDescription() {
+		String activeProfile = getActiveProfile();
 		return format("""
                 AI 컴퓨터공학부 커뮤니티 관리자, AICS-HOME ADMIN API 입니다.\n\n
                 로그인 API를 통해 액세스 토큰을 발급 받고 헤더에 값을 넣어주세요 . \n\n
@@ -103,12 +105,18 @@ public class SwaggerConfig {
                     <li>AICS-HOME API : <a href="%s" target="_blank">%s</a></li>
                 </ul>
                 """,
-			getApiSwaggerByProfile("local"), getApiSwaggerByProfile("local")
+			getApiSwaggerByProfile(activeProfile), getApiSwaggerByProfile(activeProfile)
 		);
 	}
 
 	private String getApiSwaggerByProfile(String profile) {
 		String url = (String) profileServerConfig.get(profile).get("url");
 		return url + ":" + apiPort + "/swagger-ui/index.html";
+	}
+
+	private String getActiveProfile() {
+		return Arrays.stream(environment.getActiveProfiles())
+			.findFirst()
+			.orElse("local");
 	}
 }

--- a/aics-admin/src/main/java/kgu/developers/admin/config/SwaggerConfig.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/config/SwaggerConfig.java
@@ -29,6 +29,9 @@ public class SwaggerConfig {
 
 	private final Environment environment;
 
+	@Value("${profiles.current-ip}")
+	private String currentIp;
+
 	@Value("${profiles.api-port}")
 	private int apiPort;
 
@@ -40,6 +43,7 @@ public class SwaggerConfig {
 	@PostConstruct
 	public void initializeProfileServerConfig() {
 		profileServerConfig.put("local", Map.of("url", "http://localhost", "port", adminApiPort));
+		profileServerConfig.put("dev", Map.of("url", "http://" + currentIp, "port", adminApiPort));
 	}
 
 	@Bean

--- a/aics-admin/src/main/java/kgu/developers/admin/config/SwaggerConfig.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package kgu.developers.api.config;
+package kgu.developers.admin.config;
 
 import static java.lang.String.format;
 import static org.springframework.security.config.Elements.JWT;

--- a/aics-admin/src/main/resources/application-dev.yml
+++ b/aics-admin/src/main/resources/application-dev.yml
@@ -7,3 +7,8 @@ spring:
       host: ${REDIS_HOST:redis}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
+
+profiles:
+  current-ip: ${CURRENT_IP}
+  api-port: ${API_SERVER_PORT:8080}
+  admin-api-port: ${ADMIN_API_SERVER_PORT:8081}

--- a/aics-admin/src/main/resources/application-local.yml
+++ b/aics-admin/src/main/resources/application-local.yml
@@ -2,3 +2,8 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+
+profiles:
+  current-ip: ${CURRENT_IP:localhost}
+  api-port: ${API_SERVER_PORT:8080}
+  admin-api-port: ${ADMIN_API_SERVER_PORT:8081}

--- a/aics-admin/src/main/resources/application.yml
+++ b/aics-admin/src/main/resources/application.yml
@@ -49,7 +49,3 @@ springdoc:
 jwt:
   issuer: ${JWT_ISSUER}
   secret_key: ${JWT_SECRET_KEY}
-
-profiles:
-  api-port: ${API_SERVER_PORT:8080}
-  admin-api-port: ${ADMIN_API_SERVER_PORT:8081}

--- a/aics-api/src/main/java/kgu/developers/api/config/SwaggerConfig.java
+++ b/aics-api/src/main/java/kgu/developers/api/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package kgu.developers.api.config;
 import static java.lang.String.format;
 import static org.springframework.security.config.Elements.JWT;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -93,6 +94,7 @@ public class SwaggerConfig {
 	}
 
 	private String getDescription() {
+		String activeProfile = getActiveProfile();
 		return format("""
                 AI 컴퓨터공학부 커뮤니티, AICS-HOME API 입니다.\n\n
                 로그인 API를 통해 액세스 토큰을 발급 받고 헤더에 값을 넣어주세요 . \n\n
@@ -103,12 +105,18 @@ public class SwaggerConfig {
                     <li>AICS-HOME ADMIN API : <a href="%s" target="_blank">%s</a></li>
                 </ul>
                 """,
-			getAdminSwaggerByProfile("local"), getAdminSwaggerByProfile("local")
+			getAdminSwaggerByProfile(activeProfile), getAdminSwaggerByProfile(activeProfile)
 		);
 	}
 
 	private String getAdminSwaggerByProfile(String profile) {
 		String url = (String) profileServerConfig.get(profile).get("url");
 		return url + ":" + adminApiPort + "/swagger-ui/index.html";
+	}
+
+	private String getActiveProfile() {
+		return Arrays.stream(environment.getActiveProfiles())
+			.findFirst()
+			.orElse("local");
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/config/SwaggerConfig.java
+++ b/aics-api/src/main/java/kgu/developers/api/config/SwaggerConfig.java
@@ -29,6 +29,9 @@ public class SwaggerConfig {
 
 	private final Environment environment;
 
+	@Value("${profiles.current-ip}")
+	private String currentIp;
+
 	@Value("${profiles.api-port}")
 	private int apiPort;
 
@@ -40,6 +43,7 @@ public class SwaggerConfig {
 	@PostConstruct
 	public void initializeProfileServerConfig() {
 		profileServerConfig.put("local", Map.of("url", "http://localhost", "port", apiPort));
+		profileServerConfig.put("dev", Map.of("url", "http://" + currentIp, "port", apiPort));
 	}
 
 	@Bean

--- a/aics-api/src/main/resources/application-dev.yml
+++ b/aics-api/src/main/resources/application-dev.yml
@@ -7,3 +7,8 @@ spring:
       host: ${REDIS_HOST:redis}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
+
+profiles:
+  current-ip: ${CURRENT_IP}
+  api-port: ${API_SERVER_PORT:8080}
+  admin-api-port: ${ADMIN_API_SERVER_PORT:8081}

--- a/aics-api/src/main/resources/application-local.yml
+++ b/aics-api/src/main/resources/application-local.yml
@@ -2,3 +2,8 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+
+profiles:
+  current-ip: ${CURRENT_IP:localhost}
+  api-port: ${API_SERVER_PORT:8080}
+  admin-api-port: ${ADMIN_API_SERVER_PORT:8081}

--- a/aics-api/src/main/resources/application.yml
+++ b/aics-api/src/main/resources/application.yml
@@ -47,8 +47,4 @@ jwt:
   issuer: ${JWT_ISSUER}
   secret_key: ${JWT_SECRET_KEY}
 
-profiles:
-  api-port: ${API_SERVER_PORT:8080}
-  admin-api-port: ${ADMIN_API_SERVER_PORT:8081}
-
 


### PR DESCRIPTION
## Summary

>- close #168 

개발 서버 Swagger에서 개발 서버의 ip가 표기되지 않는 버그를 픽스하였습니다.

## Tasks

- 개발 서버 Swagger에서 ip가 표기되지 않는 버그 픽스

## To Reviewer

 `local`, `dev` 환경변수를 추가하여 프로파일 별로 표시되는 ip가 다르게 하였습니다. 따라서 `local` 환경에서는 `localhost`로 `dev` 환경에서는 개발서버의 ip로 표기됩니다.

