### PR TITLE
fix/#183 LabDetailResponse 이미지 필드명 수정 및 연구실 저장 BL 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@
 aics-api.src.main.java.kgu.developers.api
 ├── foo
 │   ├── application                 // 비즈니스 로직
-│   │   └── FooFacde.java           // CQRS 패턴 적용을 위한 Facade 계층
+│   │   └── FooFacade.java           // CQRS 패턴 적용을 위한 Facade 계층
 │   └── presentation
 │       ├── response                // 응답 객체
 │       │   └── ...

--- a/aics-admin/src/main/java/kgu/developers/admin/lab/application/LabAdminFacade.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/lab/application/LabAdminFacade.java
@@ -17,8 +17,8 @@ public class LabAdminFacade {
 	private final LabCommandService labCommandService;
 	private final LabQueryService labQueryService;
 
-	public LabPersistResponse createLab(LabRequest request) {
-		Long id = labCommandService.createLab(request.name(), request.loc(), request.site(), request.advisor());
+	public LabPersistResponse createLab(Long fileId, LabRequest request) {
+		Long id = labCommandService.createLab(fileId, request.name(), request.loc(), request.site(), request.advisor());
 		return LabPersistResponse.of(id);
 	}
 

--- a/aics-admin/src/main/java/kgu/developers/admin/lab/presentation/LabAdminController.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/lab/presentation/LabAdminController.java
@@ -3,6 +3,7 @@ package kgu.developers.admin.lab.presentation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -26,6 +27,10 @@ public interface LabAdminController {
 		responseCode = "201",
 		content = @Content(schema = @Schema(implementation = LabPersistResponse.class)))
 	ResponseEntity<LabPersistResponse> createLab(
+		@Parameter(
+			description = "이미지 파일 ID는 URL 쿼리 파라미터 입니다.",
+			example = "1"
+		) @Positive @RequestParam(required = false) Long fileId,
 		@Parameter(
 			description = "연구실 생성 request 객체 입니다.",
 			required = true

--- a/aics-admin/src/main/java/kgu/developers/admin/lab/presentation/LabAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/lab/presentation/LabAdminControllerImpl.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Parameter;
@@ -30,16 +31,17 @@ public class LabAdminControllerImpl implements LabAdminController{
 	@Override
 	@PostMapping
 	public ResponseEntity<LabPersistResponse> createLab(
+		@Positive @RequestParam(required = false) Long fileId,
 		@Valid @RequestBody LabRequest request
 	) {
-		LabPersistResponse response = labAdminFacade.createLab(request);
+		LabPersistResponse response = labAdminFacade.createLab(fileId, request);
 		return ResponseEntity.status(CREATED).body(response);
 	}
 
 	@Override
 	@PatchMapping("/{id}")
 	public ResponseEntity<Void> updateLab(
-		@Parameter(description = "수정할 연구실 id", example = "1", required = true) @PathVariable @Positive Long id,
+		@PathVariable @Positive Long id,
 		@Valid @RequestBody LabRequest request
 	) {
 		labAdminFacade.updateLab(id, request);
@@ -49,7 +51,7 @@ public class LabAdminControllerImpl implements LabAdminController{
 	@Override
 	@DeleteMapping("/{id}")
 	public ResponseEntity<Void> deleteLab(
-		@Parameter(description = "삭제할 연구실의 id", example = "1", required = true) @PathVariable @Positive Long id
+		@PathVariable @Positive Long id
 	) {
 		labAdminFacade.deleteLab(id);
 		return ResponseEntity.noContent().build();

--- a/aics-admin/src/testFixtures/java/lab/application/LabAdminFacadeTest.java
+++ b/aics-admin/src/testFixtures/java/lab/application/LabAdminFacadeTest.java
@@ -13,28 +13,36 @@ import org.junit.jupiter.api.Test;
 import kgu.developers.admin.lab.application.LabAdminFacade;
 import kgu.developers.admin.lab.presentation.request.LabRequest;
 import kgu.developers.admin.lab.presentation.response.LabPersistResponse;
+import kgu.developers.domain.file.application.query.FileQueryService;
+import kgu.developers.domain.file.domain.FileEntity;
 import kgu.developers.domain.lab.application.command.LabCommandService;
 import kgu.developers.domain.lab.application.query.LabQueryService;
 import kgu.developers.domain.lab.domain.Lab;
+import mock.repository.FakeFileRepository;
 import mock.repository.FakeLabRepository;
 
 public class LabAdminFacadeTest {
 	private LabAdminFacade labAdminFacade;
 	private FakeLabRepository fakeLabRepository;
 
+	private static final Long TEST_FILE_ID = 1L;
+
 	@BeforeEach
 	public void init() {
+		FakeFileRepository fakeFileRepository = new FakeFileRepository();
 		fakeLabRepository = new FakeLabRepository();
 		labAdminFacade = new LabAdminFacade(
-			new LabCommandService(fakeLabRepository),
+			new LabCommandService(new FileQueryService(fakeFileRepository), fakeLabRepository),
 			new LabQueryService(fakeLabRepository)
 		);
 
+		FileEntity testFile = fakeFileRepository.save(FileEntity.builder().id(TEST_FILE_ID).build());
 		fakeLabRepository.save(Lab.builder()
 			.name("Lab A")
 			.loc("8500")
 			.site("http://labA.kyonggi.ac.kr")
 			.advisor("박민준")
+			.file(testFile)
 			.build()
 		);
 	}
@@ -51,7 +59,7 @@ public class LabAdminFacadeTest {
 			.build();
 
 		// when
-		LabPersistResponse response = labAdminFacade.createLab(request);
+		LabPersistResponse response = labAdminFacade.createLab(TEST_FILE_ID, request);
 
 		// then
 		Lab lab = fakeLabRepository.findById(response.id()).orElse(null);

--- a/aics-api/src/main/java/kgu/developers/api/lab/presentation/response/LabDetailResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/lab/presentation/response/LabDetailResponse.java
@@ -35,8 +35,8 @@ public record LabDetailResponse(
 			.loc(lab.getLoc())
 			.site(lab.getSite())
 			.advisor(lab.getAdvisor())
-			.img(lab.getFile() != null ?
-				FilePathResponse.from(lab.getFile()) : null)
+			.img(lab.getImgFile() != null ?
+				FilePathResponse.from(lab.getImgFile()) : null)
 			.build();
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/lab/presentation/response/LabDetailResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/lab/presentation/response/LabDetailResponse.java
@@ -22,10 +22,12 @@ public record LabDetailResponse(
 	@Schema(description = "연구실 담당교수", example = "박민준", requiredMode = REQUIRED)
 	String advisor,
 
-	@Schema(description = "첨부 파일 정보",
-		example = "{\"physicalPath\": \"/cloud/file/3/lab-logo-image\"}",
+	@Schema(description = "연구실 이미지 파일",
+		example = "{"
+			+ "\"id\": 1, "
+			+ "\"physicalPath\": \"/files/lab/20250131/lab-A.png\"}",
 		requiredMode = NOT_REQUIRED)
-	FilePathResponse file
+	FilePathResponse img
 ) {
 	public static LabDetailResponse from(Lab lab) {
 		return LabDetailResponse.builder()
@@ -33,7 +35,7 @@ public record LabDetailResponse(
 			.loc(lab.getLoc())
 			.site(lab.getSite())
 			.advisor(lab.getAdvisor())
-			.file(lab.getFile() != null ?
+			.img(lab.getFile() != null ?
 				FilePathResponse.from(lab.getFile()) : null)
 			.build();
 	}

--- a/aics-api/src/main/java/kgu/developers/api/lab/presentation/response/LabListResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/lab/presentation/response/LabListResponse.java
@@ -16,7 +16,8 @@ public record LabListResponse(
 			+ "\"loc\": \"8502, 8503\", "
 			+ "\"site\": \"http://ailab.kyonggi.ac.kr\", "
 			+ "\"professor\": \"박민준\", "
-			+ "\"img\": \"/files/lab/LAB-A.png\"}]",
+			+ "\"img\": {\"id\": 1, \"physicalPath\": \"/files/lab/20250131/lab-A.png\"}"
+			+ "}]",
 		requiredMode = REQUIRED)
 	List<LabDetailResponse> contents
 ) {

--- a/aics-domain/src/main/java/kgu/developers/domain/lab/application/command/LabCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/lab/application/command/LabCommandService.java
@@ -2,6 +2,8 @@ package kgu.developers.domain.lab.application.command;
 
 import org.springframework.stereotype.Service;
 
+import kgu.developers.domain.file.application.query.FileQueryService;
+import kgu.developers.domain.file.domain.FileEntity;
 import kgu.developers.domain.lab.domain.Lab;
 import kgu.developers.domain.lab.domain.LabRepository;
 import lombok.RequiredArgsConstructor;
@@ -9,10 +11,12 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class LabCommandService {
+	private final FileQueryService fileQueryService;
 	private final LabRepository labRepository;
 
-	public Long createLab(String name, String location, String site, String advisor) {
-		Lab lab = Lab.create(name, location, site, advisor);
+	public Long createLab(Long fileId, String name, String location, String site, String advisor) {
+		FileEntity labImageFile = fileQueryService.getFileById(fileId);
+		Lab lab = Lab.create(name, location, site, advisor, labImageFile);
 		return labRepository.save(lab).getId();
 	}
 

--- a/aics-domain/src/main/java/kgu/developers/domain/lab/domain/Lab.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/lab/domain/Lab.java
@@ -39,8 +39,8 @@ public class Lab extends BaseTimeEntity {
 	private String advisor;
 
 	@OneToOne
-	@JoinColumn(name = "file_id")
-	private FileEntity file;
+	@JoinColumn(name = "file_id", nullable = false)
+	private FileEntity imgFile;
 
 	public static Lab create(String name, String loc, String site, String advisor, FileEntity file) {
 		return Lab.builder()
@@ -48,7 +48,7 @@ public class Lab extends BaseTimeEntity {
 			.loc(loc)
 			.site(site)
 			.advisor(advisor)
-			.file(file)
+			.imgFile(file)
 			.build();
 	}
 

--- a/aics-domain/src/main/java/kgu/developers/domain/lab/domain/Lab.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/lab/domain/Lab.java
@@ -42,12 +42,13 @@ public class Lab extends BaseTimeEntity {
 	@JoinColumn(name = "file_id")
 	private FileEntity file;
 
-	public static Lab create(String name, String loc, String site, String advisor) {
+	public static Lab create(String name, String loc, String site, String advisor, FileEntity file) {
 		return Lab.builder()
 			.name(name)
 			.loc(loc)
 			.site(site)
 			.advisor(advisor)
+			.file(file)
 			.build();
 	}
 

--- a/aics-domain/src/testFixtures/java/lab/application/LabCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/lab/application/LabCommandServiceTest.java
@@ -2,14 +2,18 @@ package lab.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.File;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import kgu.developers.domain.file.application.query.FileQueryService;
+import kgu.developers.domain.file.domain.FileEntity;
 import kgu.developers.domain.lab.application.command.LabCommandService;
 import kgu.developers.domain.lab.domain.Lab;
+import mock.repository.FakeFileRepository;
 import mock.repository.FakeLabRepository;
 
 public class LabCommandServiceTest {
@@ -17,6 +21,7 @@ public class LabCommandServiceTest {
 	private FakeLabRepository fakeLabRepository;
 
 	private static final Long TARGET_LAB_ID = 2L;
+	private static final Long TEST_FILE_ID = 1L;
 
 	@BeforeEach
 	public void init() {
@@ -24,13 +29,15 @@ public class LabCommandServiceTest {
 	}
 
 	private void initializeLabCommandService() {
+		FakeFileRepository fakeFileRepository = new FakeFileRepository();
 		fakeLabRepository = new FakeLabRepository();
-		labCommandService = new LabCommandService(fakeLabRepository);
+		labCommandService = new LabCommandService(new FileQueryService(fakeFileRepository), fakeLabRepository);
 		fakeLabRepository.save(saveTestLab());
 	}
 
 	private static Lab saveTestLab() {
-		return Lab.create("인공지능 연구실", "8502, 8503", "http://ailab.kyonggi.ac.kr", "김인철");
+		return Lab.create("인공지능 연구실", "8502, 8503", "http://ailab.kyonggi.ac.kr", "김인철",
+			FileEntity.builder().id(TEST_FILE_ID).build());
 	}
 
 	@Test
@@ -43,7 +50,7 @@ public class LabCommandServiceTest {
 		String advisor = "김인철";
 
 		// when
-		Long createdLabId = labCommandService.createLab(name, loc, site, advisor);
+		Long createdLabId = labCommandService.createLab(TEST_FILE_ID, name, loc, site, advisor);
 
 		// then
 		assertEquals(TARGET_LAB_ID, createdLabId);
@@ -78,7 +85,7 @@ public class LabCommandServiceTest {
 		String site = "http://ailab.kyonggi.ac.kr";
 		String advisor = "김인철";
 
-		Long labIdToDelete = labCommandService.createLab(name, loc, site, advisor);
+		Long labIdToDelete = labCommandService.createLab(TEST_FILE_ID, name, loc, site, advisor);
 
 		// when
 		labCommandService.deleteLabById(labIdToDelete);

--- a/aics-domain/src/testFixtures/java/lab/application/LabQueryServiceTest.java
+++ b/aics-domain/src/testFixtures/java/lab/application/LabQueryServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import kgu.developers.domain.file.domain.FileEntity;
 import kgu.developers.domain.lab.application.query.LabQueryService;
 import kgu.developers.domain.lab.domain.Lab;
 import kgu.developers.domain.lab.exception.LabNotFoundException;
@@ -20,6 +21,7 @@ public class LabQueryServiceTest {
 	private static final int TARGET_LAB_COUNT = 2;
 	private static final Long TARGET_LAB_ID = 1L;
 	private static final Long NOT_EXIST_LAB_ID = 3L;
+	private static final Long TEST_FILE_ID = 1L;
 
 	@BeforeEach
 	public void init() {
@@ -30,10 +32,12 @@ public class LabQueryServiceTest {
 
 	private static void saveTestLabs(FakeLabRepository fakeLabRepository) {
 		fakeLabRepository.save(
-			Lab.create("인공지능 연구실", "8502, 8503", "http://ailab.kyonggi.ac.kr", "김인철")
+			Lab.create("인공지능 연구실", "8502, 8503", "http://ailab.kyonggi.ac.kr", "김인철",
+				FileEntity.builder().id(TEST_FILE_ID).build())
 		);
 		fakeLabRepository.save(
-			Lab.create("알고리즘 연구실", "8504", "http://algeo.kyonggi.ac.kr/", "배상원")
+			Lab.create("알고리즘 연구실", "8504", "http://algeo.kyonggi.ac.kr/", "배상원",
+				FileEntity.builder().id(TEST_FILE_ID).build())
 		);
 	}
 

--- a/aics-domain/src/testFixtures/java/lab/domain/LabDomainTest.java
+++ b/aics-domain/src/testFixtures/java/lab/domain/LabDomainTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import kgu.developers.domain.file.domain.FileEntity;
 import kgu.developers.domain.lab.domain.Lab;
 
 public class LabDomainTest {
@@ -18,7 +19,7 @@ public class LabDomainTest {
 
 	@BeforeEach
 	public void init() {
-		lab = Lab.create(NAME, LOC, SITE, ADVISOR);
+		lab = Lab.create(NAME, LOC, SITE, ADVISOR, FileEntity.builder().build());
 	}
 
 	@Test

--- a/aics-domain/src/testFixtures/java/mock/FakeTestContainer.java
+++ b/aics-domain/src/testFixtures/java/mock/FakeTestContainer.java
@@ -21,6 +21,8 @@ import kgu.developers.domain.club.domain.ClubRepository;
 import kgu.developers.domain.comment.application.command.CommentCommandService;
 import kgu.developers.domain.comment.application.query.CommentQueryService;
 import kgu.developers.domain.comment.domain.CommentRepository;
+import kgu.developers.domain.file.application.query.FileQueryService;
+import kgu.developers.domain.file.domain.FileRepository;
 import kgu.developers.domain.lab.application.command.LabCommandService;
 import kgu.developers.domain.lab.application.query.LabQueryService;
 import kgu.developers.domain.lab.domain.LabRepository;
@@ -82,7 +84,7 @@ public class FakeTestContainer {
 
 		suppliers.put(LabRepository.class, FakeLabRepository::new);
 		suppliers.put(LabQueryService.class, () -> new LabQueryService(get(LabRepository.class)));
-		suppliers.put(LabCommandService.class, () -> new LabCommandService(get(LabRepository.class)));
+		suppliers.put(LabCommandService.class, () -> new LabCommandService(get(FileQueryService.class), get(LabRepository.class)));
 
 		// Preload specific instances if necessary
 		UserRepository userRepository = get(UserRepository.class);

--- a/aics-domain/src/testFixtures/java/mock/TestContainer.java
+++ b/aics-domain/src/testFixtures/java/mock/TestContainer.java
@@ -17,6 +17,9 @@ import kgu.developers.domain.club.domain.ClubRepository;
 import kgu.developers.domain.comment.application.command.CommentCommandService;
 import kgu.developers.domain.comment.application.query.CommentQueryService;
 import kgu.developers.domain.comment.domain.CommentRepository;
+import kgu.developers.domain.file.application.command.FileCommandService;
+import kgu.developers.domain.file.application.query.FileQueryService;
+import kgu.developers.domain.file.domain.FileRepository;
 import kgu.developers.domain.lab.application.command.LabCommandService;
 import kgu.developers.domain.lab.application.query.LabQueryService;
 import kgu.developers.domain.lab.domain.LabRepository;
@@ -34,6 +37,7 @@ import kgu.developers.domain.user.domain.UserRepository;
 import mock.repository.FakeAboutRepository;
 import mock.repository.FakeClubRepository;
 import mock.repository.FakeCommentRepository;
+import mock.repository.FakeFileRepository;
 import mock.repository.FakeLabRepository;
 import mock.repository.FakePostRepository;
 import mock.repository.FakeProfessorRepository;
@@ -66,6 +70,10 @@ public class TestContainer {
 	public final ProfessorRepository professorRepository;
 	public final ProfessorQueryService professorQueryService;
 	public final ProfessorCommandService professorCommandService;
+
+	public final FileRepository fileRepository;
+	public final FileQueryService fileQueryService;
+	public final FileCommandService fileCommandService;
 
 	public final LabRepository labRepository;
 	public final LabQueryService labQueryService;
@@ -112,8 +120,12 @@ public class TestContainer {
 		this.commentQueryService = new CommentQueryService(commentRepository);
 		this.commentCommandService = new CommentCommandService(postQueryService, userQueryService, commentRepository);
 
+		this.fileRepository = new FakeFileRepository();
+		this.fileQueryService = new FileQueryService(fileRepository);
+		this.fileCommandService = new FileCommandService(fileRepository);
+
 		this.labRepository = new FakeLabRepository();
 		this.labQueryService = new LabQueryService(labRepository);
-		this.labCommandService = new LabCommandService(labRepository);
+		this.labCommandService = new LabCommandService(fileQueryService, labRepository);
 	}
 }


### PR DESCRIPTION
## Summary

>- close #183 

LabDetailResponse 이미지 필드명 수정 및 연구실 저장 BL 개선

## Tasks

- LabDetailResponse 이미지 필드명 file --> img
- 연구실 엔티티 저장 플로우 비즈니스 로직 개선

## To Reviewer

**`비즈니스 로직 개선 과정`**
기존 BL에서는 연구실 엔티티를 우선 저장하고 이미지를 업로드 하는 플로우대로 진행되었으나, 개선된 BL에서는 연구실 이미지를 먼저 업로드 합니다. 클라이언트는 업로드한 이미지 파일의 ID를 다시 연구실 엔티티 저장 API의 쿼리파라미터로 넣어, 연구실-이미지 간 연관관계 매핑을 설정합니다.
