### PR TITLE
feature/#194 게시글 API 프론트 QA 반영

### DIFF
--- a/aics-admin/src/main/java/kgu/developers/admin/post/application/PostAdminFacade.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/post/application/PostAdminFacade.java
@@ -18,8 +18,8 @@ public class PostAdminFacade {
 	private final PostQueryService postQueryService;
 	private final PostSchedulingService postSchedulingService;
 
-	public PostPersistResponse createPost(PostRequest request) {
-		Long id = postCommandService.createPost(request.title(), request.content(), request.category());
+	public PostPersistResponse createPost(Long fileId, PostRequest request) {
+		Long id = postCommandService.createPost(request.title(), request.content(), request.category(), fileId);
 		return PostPersistResponse.from(id);
 	}
 

--- a/aics-admin/src/main/java/kgu/developers/admin/post/presentation/PostAdminController.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/post/presentation/PostAdminController.java
@@ -1,9 +1,5 @@
 package kgu.developers.admin.post.presentation;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -15,6 +11,9 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import kgu.developers.admin.post.presentation.request.PostRequest;
 import kgu.developers.admin.post.presentation.response.PostPersistResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Post", description = "게시글 관리자 API")
@@ -31,7 +30,7 @@ public interface PostAdminController {
 		@Parameter(
 			description = "게시글에 저장할 파일의 ID 입니다.",
 			example = "1"
-		) @RequestParam(required = false, defaultValue = "0") Long fileId,
+		) @RequestParam(required = false) Long fileId,
 		@Parameter(
 			description = "게시글 생성 request 객체 입니다.",
 			required = true

--- a/aics-admin/src/main/java/kgu/developers/admin/post/presentation/PostAdminController.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/post/presentation/PostAdminController.java
@@ -15,6 +15,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import kgu.developers.admin.post.presentation.request.PostRequest;
 import kgu.developers.admin.post.presentation.response.PostPersistResponse;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Post", description = "게시글 관리자 API")
 public interface PostAdminController {
@@ -27,6 +28,11 @@ public interface PostAdminController {
 		responseCode = "201",
 		content = @Content(schema = @Schema(implementation = PostPersistResponse.class)))
 	ResponseEntity<PostPersistResponse> createPost(
+		@Parameter(
+			description = "게시글에 저장할 파일의 ID 입니다.",
+			example = "1",
+			required = true
+		) @Positive @RequestParam Long fileId,
 		@Parameter(
 			description = "게시글 생성 request 객체 입니다.",
 			required = true

--- a/aics-admin/src/main/java/kgu/developers/admin/post/presentation/PostAdminController.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/post/presentation/PostAdminController.java
@@ -30,9 +30,8 @@ public interface PostAdminController {
 	ResponseEntity<PostPersistResponse> createPost(
 		@Parameter(
 			description = "게시글에 저장할 파일의 ID 입니다.",
-			example = "1",
-			required = true
-		) @Positive @RequestParam Long fileId,
+			example = "1"
+		) @RequestParam(required = false, defaultValue = "0") Long fileId,
 		@Parameter(
 			description = "게시글 생성 request 객체 입니다.",
 			required = true

--- a/aics-admin/src/main/java/kgu/developers/admin/post/presentation/PostAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/post/presentation/PostAdminControllerImpl.java
@@ -29,7 +29,7 @@ public class PostAdminControllerImpl implements PostAdminController {
 	@Override
 	@PostMapping
 	public ResponseEntity<PostPersistResponse> createPost(
-		@RequestParam(required = false, defaultValue = "0") Long fileId,
+		@RequestParam(required = false) Long fileId,
 		@Valid @RequestBody PostRequest request
 	) {
 		PostPersistResponse response = postAdminFacade.createPost(fileId, request);
@@ -39,7 +39,7 @@ public class PostAdminControllerImpl implements PostAdminController {
 	@Override
 	@PatchMapping("/{postId}")
 	public ResponseEntity<Void> updatePost(
-		@Positive @PathVariable  Long postId,
+		@Positive @PathVariable Long postId,
 		@Valid @RequestBody PostRequest request
 	) {
 		postAdminFacade.updatePost(postId, request);

--- a/aics-admin/src/main/java/kgu/developers/admin/post/presentation/PostAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/post/presentation/PostAdminControllerImpl.java
@@ -1,7 +1,11 @@
 package kgu.developers.admin.post.presentation;
 
-import static org.springframework.http.HttpStatus.CREATED;
-
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import kgu.developers.admin.post.application.PostAdminFacade;
+import kgu.developers.admin.post.presentation.request.PostRequest;
+import kgu.developers.admin.post.presentation.response.PostPersistResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,12 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Positive;
-import kgu.developers.admin.post.application.PostAdminFacade;
-import kgu.developers.admin.post.presentation.request.PostRequest;
-import kgu.developers.admin.post.presentation.response.PostPersistResponse;
-import lombok.RequiredArgsConstructor;
+import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,7 +29,7 @@ public class PostAdminControllerImpl implements PostAdminController {
 	@Override
 	@PostMapping
 	public ResponseEntity<PostPersistResponse> createPost(
-		@Positive @RequestParam Long fileId,
+		@RequestParam(required = false, defaultValue = "0") Long fileId,
 		@Valid @RequestBody PostRequest request
 	) {
 		PostPersistResponse response = postAdminFacade.createPost(fileId, request);

--- a/aics-admin/src/main/java/kgu/developers/admin/post/presentation/PostAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/post/presentation/PostAdminControllerImpl.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
@@ -29,9 +30,10 @@ public class PostAdminControllerImpl implements PostAdminController {
 	@Override
 	@PostMapping
 	public ResponseEntity<PostPersistResponse> createPost(
+		@Positive @RequestParam Long fileId,
 		@Valid @RequestBody PostRequest request
 	) {
-		PostPersistResponse response = postAdminFacade.createPost(request);
+		PostPersistResponse response = postAdminFacade.createPost(fileId, request);
 		return ResponseEntity.status(CREATED).body(response);
 	}
 

--- a/aics-admin/src/main/java/kgu/developers/admin/post/presentation/request/PostRequest.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/post/presentation/request/PostRequest.java
@@ -28,7 +28,7 @@ public record PostRequest(
 	@NotBlank
 	String content,
 
-	@Schema(description = "게시물 카테고리", example = "DEPT_INFO", requiredMode = NOT_REQUIRED)
+	@Schema(description = "게시물 카테고리", example = "NOTIFICATION", requiredMode = NOT_REQUIRED)
 	Category category
 ) {
 }

--- a/aics-admin/src/testFixtures/java/post/application/PostAdminFacadeTest.java
+++ b/aics-admin/src/testFixtures/java/post/application/PostAdminFacadeTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import kgu.developers.domain.file.application.query.FileQueryService;
+import mock.repository.FakeFileRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,9 +38,11 @@ public class PostAdminFacadeTest {
 	public void init() {
 		fakePostRepository = new FakePostRepository();
 		FakeUserRepository fakeUserRepository = new FakeUserRepository();
+		FakeFileRepository fakeFileRepository = new FakeFileRepository();
 		UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
+		FileQueryService fileQueryService = new FileQueryService(fakeFileRepository);
 		this.postAdminFacade = new PostAdminFacade(
-			new PostCommandService(userQueryService, fakePostRepository),
+			new PostCommandService(userQueryService, fakePostRepository, fileQueryService),
 			new PostQueryService(fakePostRepository),
 			new PostSchedulingService(fakePostRepository)
 		);
@@ -60,7 +64,7 @@ public class PostAdminFacadeTest {
 
 		fakePostRepository.save(
 			Post.create(
-				"post title", "post content", NOTIFICATION, author
+				"post title", "post content", NOTIFICATION, author, null
 			)
 		);
 	}
@@ -74,9 +78,10 @@ public class PostAdminFacadeTest {
 			.content("new content")
 			.category(NOTIFICATION)
 			.build();
+		Long fileId = 1L;
 
 		// when
-		PostPersistResponse post = postAdminFacade.createPost(postRequest);
+		PostPersistResponse post = postAdminFacade.createPost(fileId, postRequest);
 		Post found = fakePostRepository.findByIdAndDeletedAtIsNull(post.postId()).get();
 
 		// then

--- a/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryPageResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryPageResponse.java
@@ -14,8 +14,10 @@ public record PostSummaryPageResponse<T>(
 	@Schema(description = "게시글 정보 리스트",
 		example = "[{"
 			+ "\"postId\": 3, "
+			+ "\"category\": \"공지사항\", "
 			+ "\"title\": \"SW 부트캠프 4기 교육생 모집\", "
 			+ "\"author\": \"홈피관리자\", "
+			+ "\"description\": \"2024학년도 학과 소개가 아래와 같은 일정으로 진행됩\", "
 			+ "\"views\": 19, "
 			+ "\"hasAttachment\": false, "
 			+ "\"isPinned\": false, "

--- a/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryResponse.java
@@ -1,14 +1,13 @@
 package kgu.developers.api.post.presentation.response;
 
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
-
-import java.time.format.DateTimeFormatter;
-
-import org.springframework.format.annotation.DateTimeFormat;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import kgu.developers.domain.post.domain.Post;
 import lombok.Builder;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.format.DateTimeFormatter;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 @Builder
 public record PostSummaryResponse(
@@ -42,7 +41,13 @@ public record PostSummaryResponse(
 ) {
 	public static PostSummaryResponse from(Post post) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-		String description = post.getContent().substring(0, 30);
+
+		String description;
+		try {
+			description = post.getContent().substring(0, 30);
+		} catch (StringIndexOutOfBoundsException e) {
+			description = post.getContent();
+		}
 
 		return PostSummaryResponse.builder()
 			.postId(post.getId())

--- a/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryResponse.java
@@ -24,6 +24,9 @@ public record PostSummaryResponse(
 	@Schema(description = "작성자 이름", example = "홈피관리자", requiredMode = REQUIRED)
 	String author,
 
+	@Schema(description = "게시글 내용 앞부분 30자", example = "2024학년도 학과 소개가 아래와 같은 일정으로 진행됩", requiredMode = REQUIRED)
+	String description,
+
 	@Schema(description = "조회수", example = "19", requiredMode = REQUIRED)
 	int views,
 
@@ -39,11 +42,14 @@ public record PostSummaryResponse(
 ) {
 	public static PostSummaryResponse from(Post post) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+		String description = post.getContent().substring(0, 30);
+
 		return PostSummaryResponse.builder()
 			.postId(post.getId())
 			.category(post.getCategory().getDescription())
 			.title(post.getTitle())
 			.author(post.getAuthor().getName())
+			.description(description)
 			.views(post.getViews())
 			.hasAttachment(false) // TODO : 첨부파일 여부 확인
 			.isPinned(post.isPinned())

--- a/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryResponse.java
@@ -42,12 +42,8 @@ public record PostSummaryResponse(
 	public static PostSummaryResponse from(Post post) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-		String description;
-		try {
-			description = post.getContent().substring(0, 30);
-		} catch (StringIndexOutOfBoundsException e) {
-			description = post.getContent();
-		}
+		String content = post.getContent();
+		String description = content.length() > 30 ? content.substring(0, 30) : content;
 
 		return PostSummaryResponse.builder()
 			.postId(post.getId())

--- a/aics-api/src/testFixtures/java/comment/application/CommentFacadeTest.java
+++ b/aics-api/src/testFixtures/java/comment/application/CommentFacadeTest.java
@@ -62,7 +62,7 @@ public class CommentFacadeTest {
 			.build());
 
 		Post post = fakePostRepository.save(Post.create(
-			"테스트용 제목1", "테스트용 내용1", NEWS, author
+			"테스트용 제목1", "테스트용 내용1", NEWS, author, null
 		));
 
 		fakeCommentRepository.save(Comment.create(

--- a/aics-api/src/testFixtures/java/post/application/PostFacadeTest.java
+++ b/aics-api/src/testFixtures/java/post/application/PostFacadeTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
+import kgu.developers.domain.file.application.query.FileQueryService;
+import mock.repository.FakeFileRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,11 +41,13 @@ public class PostFacadeTest {
 	public void init() {
 		FakePostRepository fakePostRepository = new FakePostRepository();
 		FakeUserRepository fakeUserRepository = new FakeUserRepository();
+		FakeFileRepository fakeFileRepository = new FakeFileRepository();
 
 		UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
+		FileQueryService fileQueryService = new FileQueryService(fakeFileRepository);
 
 		postFacade = new PostFacade(
-			new PostCommandService(userQueryService, fakePostRepository),
+			new PostCommandService(userQueryService, fakePostRepository, fileQueryService),
 			new PostQueryService(fakePostRepository)
 		);
 
@@ -63,16 +67,16 @@ public class PostFacadeTest {
 		);
 
 		fakePostRepository.save(Post.create(
-			"first title", "first content", NEWS, author
+			"first title", "first content", NEWS, author, null
 		));
 
 		Post delete = fakePostRepository.save(Post.create(
-			"second title", "second content", NEWS, author
+			"second title", "second content", NEWS, author, null
 		));
 		delete.delete();
 
 		fakePostRepository.save(Post.create(
-			"third title", "third content", NEWS, author
+			"third title", "third content", NEWS, author, null
 		));
 	}
 

--- a/aics-domain/src/main/java/kgu/developers/domain/file/application/query/FileQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/application/query/FileQueryService.java
@@ -13,6 +13,6 @@ public class FileQueryService {
 	private final FileRepository fileRepository;
 
 	public FileEntity getFileById(Long id) {
-		return fileRepository.findById(id).orElseThrow(FileNotFoundException::new);
+		return fileRepository.findById(id).orElse(null);
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/file/application/query/FileQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/application/query/FileQueryService.java
@@ -1,11 +1,9 @@
 package kgu.developers.domain.file.application.query;
 
-import org.springframework.stereotype.Service;
-
 import kgu.developers.domain.file.domain.FileEntity;
 import kgu.developers.domain.file.domain.FileRepository;
-import kgu.developers.domain.file.exception.FileNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
@@ -2,7 +2,6 @@ package kgu.developers.domain.post.application.command;
 
 import kgu.developers.domain.file.application.query.FileQueryService;
 import kgu.developers.domain.file.domain.FileEntity;
-import kgu.developers.domain.file.exception.FileNotFoundException;
 import kgu.developers.domain.post.domain.Category;
 import kgu.developers.domain.post.domain.Post;
 import kgu.developers.domain.post.domain.PostRepository;

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
@@ -22,10 +22,8 @@ public class PostCommandService {
 		User author = userQueryService.me();
 
 		FileEntity file = null;
-		try {
+		if (fileId != null)
 			file = fileQueryService.getFileById(fileId);
-		} catch (FileNotFoundException ignored) {
-		}
 
 		Post post = Post.create(title, content, category, author, file);
 		return postRepository.save(post).getId();

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
@@ -2,16 +2,14 @@ package kgu.developers.domain.post.application.command;
 
 import kgu.developers.domain.file.application.query.FileQueryService;
 import kgu.developers.domain.file.domain.FileEntity;
-import kgu.developers.domain.file.domain.FileRepository;
 import kgu.developers.domain.file.exception.FileNotFoundException;
-import org.springframework.stereotype.Service;
-
 import kgu.developers.domain.post.domain.Category;
 import kgu.developers.domain.post.domain.Post;
 import kgu.developers.domain.post.domain.PostRepository;
 import kgu.developers.domain.user.application.query.UserQueryService;
 import kgu.developers.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
@@ -1,5 +1,9 @@
 package kgu.developers.domain.post.application.command;
 
+import kgu.developers.domain.file.application.query.FileQueryService;
+import kgu.developers.domain.file.domain.FileEntity;
+import kgu.developers.domain.file.domain.FileRepository;
+import kgu.developers.domain.file.exception.FileNotFoundException;
 import org.springframework.stereotype.Service;
 
 import kgu.developers.domain.post.domain.Category;
@@ -14,10 +18,18 @@ import lombok.RequiredArgsConstructor;
 public class PostCommandService {
 	private final UserQueryService userQueryService;
 	private final PostRepository postRepository;
+	private final FileQueryService fileQueryService;
 
-	public Long createPost(String title, String content, Category category) {
+	public Long createPost(String title, String content, Category category, Long fileId) {
 		User author = userQueryService.me();
-		Post post = Post.create(title, content, category, author);
+
+		FileEntity file = null;
+		try {
+			file = fileQueryService.getFileById(fileId);
+		} catch (FileNotFoundException ignored) {
+		}
+
+		Post post = Post.create(title, content, category, author, file);
 		return postRepository.save(post).getId();
 	}
 

--- a/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
@@ -65,7 +65,7 @@ public class Post extends BaseTimeEntity {
 	@OneToMany(mappedBy = "post", fetch = LAZY, cascade = ALL, orphanRemoval = true)
 	private List<Comment> comments = new ArrayList<>();
 
-	public static Post create(String title, String content, Category category, User author) {
+	public static Post create(String title, String content, Category category, User author, FileEntity file) {
 		return Post.builder()
 			.title(title)
 			.content(content)
@@ -73,6 +73,7 @@ public class Post extends BaseTimeEntity {
 			.isPinned(false)
 			.category(category)
 			.author(author) // NOTE: User Setter 주입 방지 위해 생성자 주입
+			.file(file)
 			.build();
 	}
 

--- a/aics-domain/src/testFixtures/java/comment/application/CommentCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/comment/application/CommentCommandServiceTest.java
@@ -43,19 +43,19 @@ public class CommentCommandServiceTest {
 	}
 
 	private static void saveTestUserAndPost(FakeUserRepository fakeUserRepository,
-		FakePostRepository fakePostRepository) {
+											FakePostRepository fakePostRepository) {
 		fakeUserRepository.save(
 			User.create(TEST_USER_ID, "password1234", "홍길동", "honggildong@kyonggi.ac.kr",
 				"010-1234-5678", CSE)
 		);
 		fakePostRepository.save(Post.create(
 			"SW 부트캠프 4기 교육생 모집", "SW전문인재양성사업단에서는 SW부트캠프 4기 교육생을 모집합니다.", NEWS,
-			User.builder().build()
+			User.builder().build(), null
 		));
 	}
 
 	private void initializeCommentCommandService(FakePostRepository fakePostRepository,
-		UserQueryService userQueryService) {
+												 UserQueryService userQueryService) {
 		commentCommandService = new CommentCommandService(
 			new PostQueryService(fakePostRepository),
 			userQueryService,

--- a/aics-domain/src/testFixtures/java/comment/application/CommentQueryServiceTest.java
+++ b/aics-domain/src/testFixtures/java/comment/application/CommentQueryServiceTest.java
@@ -55,7 +55,7 @@ public class CommentQueryServiceTest {
 	private static Post saveTestPost() {
 		FakePostRepository fakePostRepository = new FakePostRepository();
 		Post commentedPost = Post.create("SW 부트캠프 4기 교육생 모집",
-			"SW전문인재양성사업단에서는 SW부트캠프 4기 교육생을 모집합니다.", NEWS, User.builder().build());
+			"SW전문인재양성사업단에서는 SW부트캠프 4기 교육생을 모집합니다.", NEWS, User.builder().build(), null);
 		return fakePostRepository.save(commentedPost);
 	}
 

--- a/aics-domain/src/testFixtures/java/comment/domain/CommentDomainTest.java
+++ b/aics-domain/src/testFixtures/java/comment/domain/CommentDomainTest.java
@@ -40,7 +40,8 @@ public class CommentDomainTest {
 			"title",
 			"content.",
 			NEWS,
-			author
+			author,
+			null
 		);
 	}
 

--- a/aics-domain/src/testFixtures/java/mock/FakeTestContainer.java
+++ b/aics-domain/src/testFixtures/java/mock/FakeTestContainer.java
@@ -74,7 +74,7 @@ public class FakeTestContainer {
 		suppliers.put(PostRepository.class, FakePostRepository::new);
 		suppliers.put(PostQueryService.class, () -> new PostQueryService(get(PostRepository.class)));
 		suppliers.put(PostCommandService.class,
-			() -> new PostCommandService(get(UserQueryService.class), get(PostRepository.class)));
+			() -> new PostCommandService(get(UserQueryService.class), get(PostRepository.class), get(FileQueryService.class)));
 
 		suppliers.put(CommentRepository.class, FakeCommentRepository::new);
 		suppliers.put(CommentQueryService.class, () -> new CommentQueryService(get(CommentRepository.class)));

--- a/aics-domain/src/testFixtures/java/mock/FakeTestContainer.java
+++ b/aics-domain/src/testFixtures/java/mock/FakeTestContainer.java
@@ -1,17 +1,5 @@
 package mock;
 
-import static kgu.developers.domain.user.domain.Major.CSE;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Supplier;
-
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-
 import kgu.developers.domain.about.application.command.AboutCommandService;
 import kgu.developers.domain.about.application.query.AboutQueryService;
 import kgu.developers.domain.about.domain.AboutRepository;
@@ -22,7 +10,6 @@ import kgu.developers.domain.comment.application.command.CommentCommandService;
 import kgu.developers.domain.comment.application.query.CommentQueryService;
 import kgu.developers.domain.comment.domain.CommentRepository;
 import kgu.developers.domain.file.application.query.FileQueryService;
-import kgu.developers.domain.file.domain.FileRepository;
 import kgu.developers.domain.lab.application.command.LabCommandService;
 import kgu.developers.domain.lab.application.query.LabQueryService;
 import kgu.developers.domain.lab.domain.LabRepository;
@@ -45,6 +32,17 @@ import mock.repository.FakePostRepository;
 import mock.repository.FakeProfessorRepository;
 import mock.repository.FakeRefreshTokenRepository;
 import mock.repository.FakeUserRepository;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static kgu.developers.domain.user.domain.Major.CSE;
 
 public class FakeTestContainer {
 	private final Map<Class<?>, Supplier<?>> suppliers = new HashMap<>();
@@ -109,6 +107,6 @@ public class FakeTestContainer {
 		if (!instances.containsKey(clazz)) {
 			instances.put(clazz, suppliers.get(clazz).get());
 		}
-		return (T)instances.get(clazz);
+		return (T) instances.get(clazz);
 	}
 }

--- a/aics-domain/src/testFixtures/java/mock/TestContainer.java
+++ b/aics-domain/src/testFixtures/java/mock/TestContainer.java
@@ -112,17 +112,17 @@ public class TestContainer {
 			new UsernamePasswordAuthenticationToken(user, user.getPassword(), user.getAuthorities())
 		);
 
+		this.fileRepository = new FakeFileRepository();
+		this.fileQueryService = new FileQueryService(fileRepository);
+		this.fileCommandService = new FileCommandService(fileRepository);
+
 		this.postRepository = new FakePostRepository();
 		this.postQueryService = new PostQueryService(postRepository);
-		this.postCommandService = new PostCommandService(userQueryService, postRepository);
+		this.postCommandService = new PostCommandService(userQueryService, postRepository, fileQueryService);
 
 		this.commentRepository = new FakeCommentRepository();
 		this.commentQueryService = new CommentQueryService(commentRepository);
 		this.commentCommandService = new CommentCommandService(postQueryService, userQueryService, commentRepository);
-
-		this.fileRepository = new FakeFileRepository();
-		this.fileQueryService = new FileQueryService(fileRepository);
-		this.fileCommandService = new FileCommandService(fileRepository);
 
 		this.labRepository = new FakeLabRepository();
 		this.labQueryService = new LabQueryService(labRepository);

--- a/aics-domain/src/testFixtures/java/post/application/PostCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/post/application/PostCommandServiceTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import kgu.developers.domain.file.application.query.FileQueryService;
+import mock.repository.FakeFileRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,11 +30,13 @@ public class PostCommandServiceTest {
 	@BeforeEach
 	public void init() {
 		FakeUserRepository fakeUserRepository = new FakeUserRepository();
+		FakeFileRepository fakeFileRepository = new FakeFileRepository();
 		UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
 
 		postCommandService = new PostCommandService(
 			userQueryService,
-			new FakePostRepository()
+			new FakePostRepository(),
+			new FileQueryService(fakeFileRepository)
 		);
 
 		fakeUserRepository.save(User.builder()
@@ -58,9 +62,10 @@ public class PostCommandServiceTest {
 		String title = "test";
 		String content = "test";
 		Category category = NOTIFICATION;
+		Long fileId = 1L;
 
 		// when
-		Long result = postCommandService.createPost(title, content, category);
+		Long result = postCommandService.createPost(title, content, category, fileId);
 
 		// then
 		assertEquals(1L, result);

--- a/aics-domain/src/testFixtures/java/post/application/PostQueryServiceTest.java
+++ b/aics-domain/src/testFixtures/java/post/application/PostQueryServiceTest.java
@@ -34,28 +34,28 @@ public class PostQueryServiceTest {
 
 		fakePostRepository.save(Post.create(
 			"테스트용 제목1", "테스트용 내용1",
-			NEWS, author
+			NEWS, author, null
 		));
 
 		fakePostRepository.save(Post.create(
 			"테스트용 제목2", "테스트용 내용2",
-			NEWS, author
+			NEWS, author, null
 		));
 
 		Post delete = fakePostRepository.save(Post.create(
 			"테스트용 제목3", "테스트용 내용3",
-			NEWS, author
+			NEWS, author, null
 		));
 		delete.delete();
 
 		fakePostRepository.save(Post.create(
 			"테스트용 제목4", "테스트용 내용4",
-			NOTIFICATION, author
+			NOTIFICATION, author, null
 		));
 
 		fakePostRepository.save(Post.create(
 			"테스트용 제목5", "테스트용 내용5",
-			NEWS, author
+			NEWS, author, null
 		));
 	}
 

--- a/aics-domain/src/testFixtures/java/post/domain/PostDomainTest.java
+++ b/aics-domain/src/testFixtures/java/post/domain/PostDomainTest.java
@@ -26,7 +26,7 @@ public class PostDomainTest {
 	@BeforeEach
 	public void init() {
 		User author = user();
-		post = Post.create(TITLE, CONTENT, NEWS, author);
+		post = Post.create(TITLE, CONTENT, NEWS, author, null);
 	}
 
 	private User user() {


### PR DESCRIPTION
## Summary

>- #194 

FE에서 요청한 게시글 API QA를 반영합니다.

## Tasks

- PostSummaryResponse에 description 필드 추가
- Post 생성 API에 파라미터로 fileId 추가

## To Reviewer

Post 생성 AP에 fileId를 추가하는 과정에서 null 값이 넘어오는 경우에 대해 예외처리를 할 때, 
파급의 길이가 길고, 다소 투박하게 처리되는 것 같은 느낌을 받았습니다.
혹시 개선할만한 부분에 대해서 아이디어 주시면 감사하겠습니다!