### PR TITLE
feature/#201 회원 비밀번호 변경 구현

### DIFF
--- a/aics-api/src/main/java/kgu/developers/api/user/application/UserFacade.java
+++ b/aics-api/src/main/java/kgu/developers/api/user/application/UserFacade.java
@@ -1,5 +1,6 @@
 package kgu.developers.api.user.application;
 
+import kgu.developers.api.user.presentation.request.UserPasswordUpdateRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,5 +35,10 @@ public class UserFacade {
 
 	public UserDetailResponse getUserDetail() {
 		return userQueryService.getUserDetail();
+	}
+
+	public void updatePassword(UserPasswordUpdateRequest request) {
+		User user = userQueryService.me();
+		userCommandService.updatePassword(user, request.originalPassword(), request.newPassword());
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/user/presentation/UserController.java
+++ b/aics-api/src/main/java/kgu/developers/api/user/presentation/UserController.java
@@ -59,8 +59,7 @@ public interface UserController {
 			- Description : 이 API는 회원의 비밀번호를 수정 합니다.
 			- Assignee : 이신행
 		""")
-	@ApiResponse(
-		responseCode = "204")
+	@ApiResponse(responseCode = "204")
 	ResponseEntity<Void> updatePassword(
 		@Parameter(
 			description = "회원 비밀번호 수정 request 객체 입니다.",

--- a/aics-api/src/main/java/kgu/developers/api/user/presentation/UserController.java
+++ b/aics-api/src/main/java/kgu/developers/api/user/presentation/UserController.java
@@ -1,5 +1,6 @@
 package kgu.developers.api.user.presentation;
 
+import kgu.developers.api.user.presentation.request.UserPasswordUpdateRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -53,5 +54,19 @@ public interface UserController {
 			description = "회원 정보 수정 request 객체 입니다.",
 			required = true
 		) @Valid @RequestBody UserUpdateRequest request
+	);
+
+	@Operation(summary = "회원 비밀번호 수정 API", description = """
+			- Description : 이 API는 회원의 비밀번호를 수정 합니다.
+			- Assignee : 이신행
+		""")
+	@ApiResponse(
+		responseCode = "204",
+		content = @Content(schema = @Schema(implementation = UserUpdateRequest.class)))
+	ResponseEntity<Void> updatePassword(
+		@Parameter(
+			description = "회원 비밀번호 수정 request 객체 입니다.",
+			required = true
+		) @Valid @RequestBody UserPasswordUpdateRequest request
 	);
 }

--- a/aics-api/src/main/java/kgu/developers/api/user/presentation/UserController.java
+++ b/aics-api/src/main/java/kgu/developers/api/user/presentation/UserController.java
@@ -1,9 +1,5 @@
 package kgu.developers.api.user.presentation;
 
-import kgu.developers.api.user.presentation.request.UserPasswordUpdateRequest;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestBody;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -12,9 +8,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kgu.developers.api.user.presentation.request.UserCreateRequest;
+import kgu.developers.api.user.presentation.request.UserPasswordUpdateRequest;
 import kgu.developers.api.user.presentation.request.UserUpdateRequest;
 import kgu.developers.api.user.presentation.response.UserPersistResponse;
 import kgu.developers.domain.user.application.response.UserDetailResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "User", description = "회원 API")
 public interface UserController {
@@ -61,8 +60,7 @@ public interface UserController {
 			- Assignee : 이신행
 		""")
 	@ApiResponse(
-		responseCode = "204",
-		content = @Content(schema = @Schema(implementation = UserUpdateRequest.class)))
+		responseCode = "204")
 	ResponseEntity<Void> updatePassword(
 		@Parameter(
 			description = "회원 비밀번호 수정 request 객체 입니다.",

--- a/aics-api/src/main/java/kgu/developers/api/user/presentation/UserControllerImpl.java
+++ b/aics-api/src/main/java/kgu/developers/api/user/presentation/UserControllerImpl.java
@@ -2,6 +2,7 @@ package kgu.developers.api.user.presentation;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
+import kgu.developers.api.user.presentation.request.UserPasswordUpdateRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -46,6 +47,15 @@ public class UserControllerImpl implements UserController{
 		@Valid @RequestBody UserUpdateRequest request
 	) {
 		userFacade.updateUser(request);
+		return ResponseEntity.noContent().build();
+	}
+
+	@Override
+	@PatchMapping
+	public ResponseEntity<Void> updatePassword(
+		@Valid @RequestBody UserPasswordUpdateRequest request
+	) {
+		userFacade.updatePassword(request);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/user/presentation/UserControllerImpl.java
+++ b/aics-api/src/main/java/kgu/developers/api/user/presentation/UserControllerImpl.java
@@ -1,8 +1,13 @@
 package kgu.developers.api.user.presentation;
 
-import static org.springframework.http.HttpStatus.CREATED;
-
+import jakarta.validation.Valid;
+import kgu.developers.api.user.application.UserFacade;
+import kgu.developers.api.user.presentation.request.UserCreateRequest;
 import kgu.developers.api.user.presentation.request.UserPasswordUpdateRequest;
+import kgu.developers.api.user.presentation.request.UserUpdateRequest;
+import kgu.developers.api.user.presentation.response.UserPersistResponse;
+import kgu.developers.domain.user.application.response.UserDetailResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -11,18 +16,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import jakarta.validation.Valid;
-import kgu.developers.api.user.application.UserFacade;
-import kgu.developers.api.user.presentation.request.UserCreateRequest;
-import kgu.developers.api.user.presentation.request.UserUpdateRequest;
-import kgu.developers.api.user.presentation.response.UserPersistResponse;
-import kgu.developers.domain.user.application.response.UserDetailResponse;
-import lombok.RequiredArgsConstructor;
+import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
-public class UserControllerImpl implements UserController{
+public class UserControllerImpl implements UserController {
 	private final UserFacade userFacade;
 
 	@Override
@@ -51,7 +50,7 @@ public class UserControllerImpl implements UserController{
 	}
 
 	@Override
-	@PatchMapping
+	@PatchMapping("/password")
 	public ResponseEntity<Void> updatePassword(
 		@Valid @RequestBody UserPasswordUpdateRequest request
 	) {

--- a/aics-api/src/main/java/kgu/developers/api/user/presentation/request/UserPasswordUpdateRequest.java
+++ b/aics-api/src/main/java/kgu/developers/api/user/presentation/request/UserPasswordUpdateRequest.java
@@ -1,0 +1,28 @@
+package kgu.developers.api.user.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+@Builder
+public record UserPasswordUpdateRequest(
+	@Schema(description = "원래 비밀번호", example = "password1234!", requiredMode = REQUIRED)
+	@Pattern(
+		regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*(),.?\":{}|<>])[A-Za-z\\d!@#$%^&*(),.?\":{}|<>]{8,15}$",
+		message = "비밀번호는 영문, 숫자, 특수문자를 포함하여 8~15자리여야 합니다."
+	)
+	@NotNull
+	String originalPassword,
+
+	@Schema(description = "새로운 비밀번호", example = "newpass1234!", requiredMode = REQUIRED)
+	@Pattern(
+		regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*(),.?\":{}|<>])[A-Za-z\\d!@#$%^&*(),.?\":{}|<>]{8,15}$",
+		message = "비밀번호는 영문, 숫자, 특수문자를 포함하여 8~15자리여야 합니다."
+	)
+	@NotNull
+	String newPassword
+) {
+}

--- a/aics-api/src/testFixtures/java/user/application/UserFacadeTest.java
+++ b/aics-api/src/testFixtures/java/user/application/UserFacadeTest.java
@@ -10,7 +10,6 @@ import kgu.developers.domain.user.application.query.UserQueryService;
 import kgu.developers.domain.user.application.response.UserDetailResponse;
 import kgu.developers.domain.user.domain.User;
 import kgu.developers.domain.user.exception.InvalidPasswordException;
-import kgu.developers.domain.user.exception.UserIdDuplicateException;
 import mock.repository.FakeUserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/aics-api/src/testFixtures/java/user/application/UserFacadeTest.java
+++ b/aics-api/src/testFixtures/java/user/application/UserFacadeTest.java
@@ -1,8 +1,17 @@
 package user.application;
 
-import static kgu.developers.domain.user.domain.Major.CSE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
+import kgu.developers.api.user.application.UserFacade;
+import kgu.developers.api.user.presentation.request.UserCreateRequest;
+import kgu.developers.api.user.presentation.request.UserPasswordUpdateRequest;
+import kgu.developers.api.user.presentation.request.UserUpdateRequest;
+import kgu.developers.api.user.presentation.response.UserPersistResponse;
+import kgu.developers.domain.user.application.command.UserCommandService;
+import kgu.developers.domain.user.application.query.UserQueryService;
+import kgu.developers.domain.user.application.response.UserDetailResponse;
+import kgu.developers.domain.user.domain.User;
+import kgu.developers.domain.user.exception.InvalidPasswordException;
+import kgu.developers.domain.user.exception.UserIdDuplicateException;
+import mock.repository.FakeUserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,15 +21,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-import kgu.developers.api.user.application.UserFacade;
-import kgu.developers.api.user.presentation.request.UserCreateRequest;
-import kgu.developers.api.user.presentation.request.UserUpdateRequest;
-import kgu.developers.api.user.presentation.response.UserPersistResponse;
-import kgu.developers.domain.user.application.command.UserCommandService;
-import kgu.developers.domain.user.application.query.UserQueryService;
-import kgu.developers.domain.user.application.response.UserDetailResponse;
-import kgu.developers.domain.user.domain.User;
-import mock.repository.FakeUserRepository;
+import static kgu.developers.domain.user.domain.Major.CSE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UserFacadeTest {
 	private UserFacade userFacade;
@@ -29,14 +33,15 @@ public class UserFacadeTest {
 	public void init() {
 		FakeUserRepository fakeUserRepository = new FakeUserRepository();
 		UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
+		BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 		userFacade = new UserFacade(
 			userQueryService,
-			new UserCommandService(new BCryptPasswordEncoder(), fakeUserRepository)
+			new UserCommandService(passwordEncoder, fakeUserRepository)
 		);
 
 		fakeUserRepository.save(User.builder()
 			.id("202411345")
-			.password("password1234")
+			.password(passwordEncoder.encode("password1234"))
 			.name("홍길동")
 			.email("test@kyonggi.ac.kr")
 			.phone("010-1234-5678")
@@ -101,5 +106,33 @@ public class UserFacadeTest {
 		assertEquals("test@kyonggi.ac.kr", result.email());
 		assertEquals("010-1234-5678", result.phone());
 		assertEquals(CSE, result.major());
+	}
+
+	@Test
+	@DisplayName("updatePassword는 주어진 형식으로 변경하는 경우 예외를 던지지 않는다")
+	public void updatePassword_Success() {
+		// given
+		UserPasswordUpdateRequest request = UserPasswordUpdateRequest.builder()
+			.originalPassword("password1234")
+			.newPassword("newpass1234")
+			.build();
+
+		// then
+		assertDoesNotThrow(() -> userFacade.updatePassword(request));
+	}
+
+	@Test
+	@DisplayName("updatePassword는 원래 비밀번호를 잘못 입력할 경우 예외를 발생시킨다")
+	public void updatePassword_ThrowsException() {
+		// given
+		UserPasswordUpdateRequest request = UserPasswordUpdateRequest.builder()
+			.originalPassword("wrong1234")
+			.newPassword("newpass1234")
+			.build();
+
+		// when
+		// then
+		assertThatThrownBy(() -> userFacade.updatePassword(request))
+			.isInstanceOf(InvalidPasswordException.class);
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/user/application/command/UserCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/application/command/UserCommandService.java
@@ -3,8 +3,6 @@ package kgu.developers.domain.user.application.command;
 import kgu.developers.domain.user.domain.Major;
 import kgu.developers.domain.user.domain.User;
 import kgu.developers.domain.user.domain.UserRepository;
-import kgu.developers.domain.user.exception.DuplicatePasswordException;
-import kgu.developers.domain.user.exception.InvalidPasswordException;
 import kgu.developers.domain.user.exception.UserIdDuplicateException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -33,14 +31,7 @@ public class UserCommandService {
 	}
 
 	public void updatePassword(User user, String originalPassword, String newPassword) {
-		try {
-			user.isPasswordMatching(newPassword, bCryptPasswordEncoder);
-			throw new DuplicatePasswordException();
-		} catch (InvalidPasswordException ignore) {
-		}
-
-		System.out.println(user.getPassword());
-		System.out.println(encodePassword(newPassword));
+		user.isNewPasswordMatching(newPassword, bCryptPasswordEncoder);
 		user.isPasswordMatching(originalPassword, bCryptPasswordEncoder);
 		user.updatePassword(encodePassword(newPassword));
 	}

--- a/aics-domain/src/main/java/kgu/developers/domain/user/application/command/UserCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/application/command/UserCommandService.java
@@ -4,6 +4,7 @@ import kgu.developers.domain.user.domain.Major;
 import kgu.developers.domain.user.domain.User;
 import kgu.developers.domain.user.domain.UserRepository;
 import kgu.developers.domain.user.exception.DuplicatePasswordException;
+import kgu.developers.domain.user.exception.InvalidPasswordException;
 import kgu.developers.domain.user.exception.UserIdDuplicateException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -17,8 +18,7 @@ public class UserCommandService {
 
 	public String createUser(String userId, String password, String name, String email, String phone, Major major) {
 		validateDuplicateId(userId);
-		String encodedPassword = bCryptPasswordEncoder.encode(password);
-		User user = User.create(userId, encodedPassword, name, email, phone, major);
+		User user = User.create(userId, encodePassword(password), name, email, phone, major);
 		return userRepository.save(user).getId();
 	}
 
@@ -33,11 +33,19 @@ public class UserCommandService {
 	}
 
 	public void updatePassword(User user, String originalPassword, String newPassword) {
-		if (user.isPasswordMatching(newPassword, bCryptPasswordEncoder))
+		try {
+			user.isPasswordMatching(newPassword, bCryptPasswordEncoder);
 			throw new DuplicatePasswordException();
+		} catch (InvalidPasswordException ignore) {
+		}
 
+		System.out.println(user.getPassword());
+		System.out.println(encodePassword(newPassword));
 		user.isPasswordMatching(originalPassword, bCryptPasswordEncoder);
-		String encodedPassword = bCryptPasswordEncoder.encode(newPassword);
-		user.updatePassword(encodedPassword);
+		user.updatePassword(encodePassword(newPassword));
+	}
+
+	private String encodePassword(String password) {
+		return bCryptPasswordEncoder.encode(password);
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/user/application/command/UserCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/application/command/UserCommandService.java
@@ -1,13 +1,13 @@
 package kgu.developers.domain.user.application.command;
 
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.stereotype.Service;
-
 import kgu.developers.domain.user.domain.Major;
 import kgu.developers.domain.user.domain.User;
 import kgu.developers.domain.user.domain.UserRepository;
+import kgu.developers.domain.user.exception.DuplicatePasswordException;
 import kgu.developers.domain.user.exception.UserIdDuplicateException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +33,9 @@ public class UserCommandService {
 	}
 
 	public void updatePassword(User user, String originalPassword, String newPassword) {
+		if (user.isPasswordMatching(newPassword, bCryptPasswordEncoder))
+			throw new DuplicatePasswordException();
+
 		user.isPasswordMatching(originalPassword, bCryptPasswordEncoder);
 		String encodedPassword = bCryptPasswordEncoder.encode(newPassword);
 		user.updatePassword(encodedPassword);

--- a/aics-domain/src/main/java/kgu/developers/domain/user/application/command/UserCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/application/command/UserCommandService.java
@@ -16,7 +16,7 @@ public class UserCommandService {
 
 	public String createUser(String userId, String password, String name, String email, String phone, Major major) {
 		validateDuplicateId(userId);
-		User user = User.create(userId, encodePassword(password), name, email, phone, major);
+		User user = User.create(userId, password, name, email, phone, major,  bCryptPasswordEncoder);
 		return userRepository.save(user).getId();
 	}
 
@@ -33,10 +33,6 @@ public class UserCommandService {
 	public void updatePassword(User user, String originalPassword, String newPassword) {
 		user.isNewPasswordMatching(newPassword, bCryptPasswordEncoder);
 		user.isPasswordMatching(originalPassword, bCryptPasswordEncoder);
-		user.updatePassword(encodePassword(newPassword));
-	}
-
-	private String encodePassword(String password) {
-		return bCryptPasswordEncoder.encode(password);
+		user.updatePassword(newPassword,  bCryptPasswordEncoder);
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/user/application/command/UserCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/application/command/UserCommandService.java
@@ -31,4 +31,10 @@ public class UserCommandService {
 		if (userRepository.existsById(id))
 			throw new UserIdDuplicateException();
 	}
+
+	public void updatePassword(User user, String originalPassword, String newPassword) {
+		user.isPasswordMatching(originalPassword, bCryptPasswordEncoder);
+		String encodedPassword = bCryptPasswordEncoder.encode(newPassword);
+		user.updatePassword(encodedPassword);
+	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
@@ -10,6 +10,7 @@ import kgu.developers.common.domain.BaseRole;
 import kgu.developers.common.domain.BaseTimeEntity;
 import kgu.developers.domain.post.domain.Post;
 import kgu.developers.domain.user.exception.DeptCodeNotValidException;
+import kgu.developers.domain.user.exception.DuplicatePasswordException;
 import kgu.developers.domain.user.exception.EmailDomainNotValidException;
 import kgu.developers.domain.user.exception.InvalidPasswordException;
 import lombok.AllArgsConstructor;
@@ -135,7 +136,7 @@ public class User extends BaseTimeEntity implements UserDetails {
 
 	public void isNewPasswordMatching(String rawPassword, PasswordEncoder passwordEncoder) {
 		if (passwordEncoder.matches(rawPassword, this.password)) {
-			throw new InvalidPasswordException();
+			throw new DuplicatePasswordException();
 		}
 	}
 

--- a/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
@@ -133,4 +133,8 @@ public class User extends BaseTimeEntity implements UserDetails {
 			throw new InvalidPasswordException();
 		}
 	}
+
+	public void updatePassword(String password) {
+		this.password = password;
+	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
@@ -128,10 +128,11 @@ public class User extends BaseTimeEntity implements UserDetails {
 			.anyMatch(email::endsWith);
 	}
 
-	public void isPasswordMatching(String rawPassword, PasswordEncoder passwordEncoder) {
+	public boolean isPasswordMatching(String rawPassword, PasswordEncoder passwordEncoder) {
 		if (!passwordEncoder.matches(rawPassword, this.password)) {
 			throw new InvalidPasswordException();
 		}
+		return true;
 	}
 
 	public void updatePassword(String password) {

--- a/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
@@ -1,21 +1,5 @@
 package kgu.developers.domain.user.domain;
 
-import static jakarta.persistence.CascadeType.ALL;
-import static jakarta.persistence.EnumType.STRING;
-import static jakarta.persistence.FetchType.LAZY;
-import static kgu.developers.domain.user.domain.DeptCode.isValidDeptCode;
-import static lombok.AccessLevel.PROTECTED;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.crypto.password.PasswordEncoder;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
@@ -32,6 +16,21 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static kgu.developers.domain.user.domain.DeptCode.isValidDeptCode;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
@@ -130,6 +129,12 @@ public class User extends BaseTimeEntity implements UserDetails {
 
 	public void isPasswordMatching(String rawPassword, PasswordEncoder passwordEncoder) {
 		if (!passwordEncoder.matches(rawPassword, this.password)) {
+			throw new InvalidPasswordException();
+		}
+	}
+
+	public void isNewPasswordMatching(String rawPassword, PasswordEncoder passwordEncoder) {
+		if (passwordEncoder.matches(rawPassword, this.password)) {
 			throw new InvalidPasswordException();
 		}
 	}

--- a/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
@@ -69,11 +69,12 @@ public class User extends BaseTimeEntity implements UserDetails {
 	@OneToMany(mappedBy = "author", cascade = ALL, fetch = LAZY)
 	List<Post> posts = new ArrayList<>();
 
-	public static User create(String id, String password, String name, String email, String phone, Major major) {
+	public static User create(String id, String password, String name, String email,
+							  String phone, Major major, PasswordEncoder passwordEncoder) {
 		validateDept(id, email);
 		return User.builder()
 			.id(id)
-			.password(password)
+			.password(encodePassword(password, passwordEncoder))
 			.name(name)
 			.email(email)
 			.phone(phone)
@@ -140,7 +141,11 @@ public class User extends BaseTimeEntity implements UserDetails {
 		}
 	}
 
-	public void updatePassword(String password) {
-		this.password = password;
+	public void updatePassword(String password, PasswordEncoder passwordEncoder) {
+		this.password = encodePassword(password, passwordEncoder);
+	}
+
+	private static String encodePassword(String password, PasswordEncoder passwordEncoder) {
+		return passwordEncoder.encode(password);
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
@@ -128,11 +128,10 @@ public class User extends BaseTimeEntity implements UserDetails {
 			.anyMatch(email::endsWith);
 	}
 
-	public boolean isPasswordMatching(String rawPassword, PasswordEncoder passwordEncoder) {
+	public void isPasswordMatching(String rawPassword, PasswordEncoder passwordEncoder) {
 		if (!passwordEncoder.matches(rawPassword, this.password)) {
 			throw new InvalidPasswordException();
 		}
-		return true;
 	}
 
 	public void updatePassword(String password) {

--- a/aics-domain/src/main/java/kgu/developers/domain/user/exception/DuplicatePasswordException.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/exception/DuplicatePasswordException.java
@@ -1,0 +1,11 @@
+package kgu.developers.domain.user.exception;
+
+import kgu.developers.common.exception.CustomException;
+
+import static kgu.developers.domain.user.exception.UserDomainExceptionCode.DUPLICATE_PASSWORD;
+
+public class DuplicatePasswordException extends CustomException {
+	public DuplicatePasswordException() {
+		super(DUPLICATE_PASSWORD);
+	}
+}

--- a/aics-domain/src/main/java/kgu/developers/domain/user/exception/UserDomainExceptionCode.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/exception/UserDomainExceptionCode.java
@@ -17,6 +17,7 @@ public enum UserDomainExceptionCode implements ExceptionCode {
 	EMAIL_NOT_VALID(BAD_REQUEST, "학교 이메일 형식이 아닙니다."),
 	DEPT_CODE_NOT_VALID(BAD_REQUEST, "학번별 학과 코드가 일치하지 않습니다."),
 	INVALID_PASSWORD(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+	DUPLICATE_PASSWORD(BAD_REQUEST, "기존 비밀번호와 동일한 비밀번호는 불가능합니다."),
 	USER_NOT_AUTHENTICATED(UNAUTHORIZED, "회원 인증에 실패하였습니다."),
 	USER_NOT_FOUND(NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
 	USER_ID_DUPLICATED(CONFLICT, "이미 동일한 학번으로 가입이 되어있습니다."),

--- a/aics-domain/src/testFixtures/java/comment/application/CommentCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/comment/application/CommentCommandServiceTest.java
@@ -23,6 +23,8 @@ import kgu.developers.domain.user.domain.User;
 import mock.repository.FakeCommentRepository;
 import mock.repository.FakePostRepository;
 import mock.repository.FakeUserRepository;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 public class CommentCommandServiceTest {
 	private CommentCommandService commentCommandService;
@@ -30,6 +32,7 @@ public class CommentCommandServiceTest {
 	private static final Long TARGET_COMMENT_ID = 1L;
 	private static final Long TEST_POST_ID = 1L;
 	private static final String TEST_USER_ID = "202411345";
+	private static final PasswordEncoder PASSWORD_ENCODER = new BCryptPasswordEncoder();
 
 	@BeforeEach
 	public void init() {
@@ -46,7 +49,7 @@ public class CommentCommandServiceTest {
 											FakePostRepository fakePostRepository) {
 		fakeUserRepository.save(
 			User.create(TEST_USER_ID, "password1234", "홍길동", "honggildong@kyonggi.ac.kr",
-				"010-1234-5678", CSE)
+				"010-1234-5678", CSE,  PASSWORD_ENCODER)
 		);
 		fakePostRepository.save(Post.create(
 			"SW 부트캠프 4기 교육생 모집", "SW전문인재양성사업단에서는 SW부트캠프 4기 교육생을 모집합니다.", NEWS,

--- a/aics-domain/src/testFixtures/java/comment/domain/CommentDomainTest.java
+++ b/aics-domain/src/testFixtures/java/comment/domain/CommentDomainTest.java
@@ -12,10 +12,13 @@ import org.junit.jupiter.api.Test;
 import kgu.developers.domain.comment.domain.Comment;
 import kgu.developers.domain.post.domain.Post;
 import kgu.developers.domain.user.domain.User;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 public class CommentDomainTest {
 	private Comment comment;
 	private static final String CONTENT = "content";
+	private static final PasswordEncoder PASSWORD_ENCODER = new BCryptPasswordEncoder();
 
 	private User getUser() {
 		return User.create(
@@ -24,7 +27,8 @@ public class CommentDomainTest {
 			"홍길동",
 			"valid@kyonggi.ac.kr",
 			"010-1234-5678",
-			CSE
+			CSE,
+			PASSWORD_ENCODER
 		);
 	}
 

--- a/aics-domain/src/testFixtures/java/post/domain/PostDomainTest.java
+++ b/aics-domain/src/testFixtures/java/post/domain/PostDomainTest.java
@@ -17,11 +17,14 @@ import org.junit.jupiter.api.Test;
 import kgu.developers.domain.post.domain.Category;
 import kgu.developers.domain.post.domain.Post;
 import kgu.developers.domain.user.domain.User;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 public class PostDomainTest {
 	private Post post;
 	private static final String TITLE = "Valid Title";
 	private static final String CONTENT = "This is valid content.";
+	private static final PasswordEncoder PASSWORD_ENCODER = new BCryptPasswordEncoder();
 
 	@BeforeEach
 	public void init() {
@@ -34,7 +37,9 @@ public class PostDomainTest {
 			"password",
 			"홍길동",
 			"valid@kyonggi.ac.kr",
-			"010-1234-5678", CSE);
+			"010-1234-5678",
+			CSE,
+			PASSWORD_ENCODER);
 	}
 
 	@Test

--- a/aics-domain/src/testFixtures/java/user/application/UserCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/user/application/UserCommandServiceTest.java
@@ -3,6 +3,7 @@ package user.application;
 import kgu.developers.domain.user.application.command.UserCommandService;
 import kgu.developers.domain.user.domain.Major;
 import kgu.developers.domain.user.domain.User;
+import kgu.developers.domain.user.exception.DuplicatePasswordException;
 import kgu.developers.domain.user.exception.UserIdDuplicateException;
 import mock.repository.FakeUserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -96,5 +97,18 @@ public class UserCommandServiceTest {
 		// when
 		// then
 		assertDoesNotThrow(() -> userCommandService.updatePassword(user, originalPassword, newPassword));
+	}
+
+	@Test
+	@DisplayName("updatePassword는 기존 비밀번호와 같은 비밀번호로 수정하면 DuplicatePasswordException를 발생시킨다")
+	public void updatePassword_ThrowsException() {
+		// given
+		String originalPassword = "password";
+		String newPassword = "password";
+
+		// when
+		// then
+		assertThatThrownBy(() -> userCommandService.updatePassword(user, originalPassword, newPassword))
+			.isInstanceOf(DuplicatePasswordException.class);
 	}
 }

--- a/aics-domain/src/testFixtures/java/user/application/UserCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/user/application/UserCommandServiceTest.java
@@ -2,8 +2,10 @@ package user.application;
 
 import static kgu.developers.domain.user.domain.Major.CSE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import kgu.developers.domain.user.domain.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,19 +19,22 @@ import mock.repository.FakeUserRepository;
 
 public class UserCommandServiceTest {
 	private UserCommandService userCommandService;
+	private User user;
 
 	@BeforeEach
 	public void init() {
 		FakeUserRepository fakeUserRepository = new FakeUserRepository();
+		BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 		userCommandService = new UserCommandService(
 			new BCryptPasswordEncoder(),
 			fakeUserRepository
 		);
 
-		fakeUserRepository.save(User.builder()
+		user = User.builder()
 			.id("202411345")
-			.build()
-		);
+			.password(passwordEncoder.encode("password"))
+			.build();
+		fakeUserRepository.save(user);
 	}
 
 	@Test
@@ -81,5 +86,17 @@ public class UserCommandServiceTest {
 		// then
 		assertEquals("kim@kyonggi.ac.kr", user.getEmail());
 		assertEquals("010-0000-0000", user.getPhone());
+	}
+
+	@Test
+	@DisplayName("updatePassword는 User의 비밀번호를 수정할 수 있다")
+	public void updatePassword_Success() {
+		// given
+		String originalPassword = "password";
+		String newPassword = "newPassword";
+
+		// when
+		// then
+		assertDoesNotThrow(() -> userCommandService.updatePassword(user, originalPassword, newPassword));
 	}
 }

--- a/aics-domain/src/testFixtures/java/user/application/UserCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/user/application/UserCommandServiceTest.java
@@ -1,21 +1,19 @@
 package user.application;
 
-import static kgu.developers.domain.user.domain.Major.CSE;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import kgu.developers.domain.user.domain.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-
 import kgu.developers.domain.user.application.command.UserCommandService;
 import kgu.developers.domain.user.domain.Major;
 import kgu.developers.domain.user.domain.User;
 import kgu.developers.domain.user.exception.UserIdDuplicateException;
 import mock.repository.FakeUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static kgu.developers.domain.user.domain.Major.CSE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UserCommandServiceTest {
 	private UserCommandService userCommandService;

--- a/aics-domain/src/testFixtures/java/user/domain/UserDomainTest.java
+++ b/aics-domain/src/testFixtures/java/user/domain/UserDomainTest.java
@@ -1,21 +1,23 @@
 package user.domain;
 
-import static kgu.developers.domain.user.domain.Major.CSE;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-
 import kgu.developers.common.domain.BaseRole;
 import kgu.developers.domain.user.domain.Major;
 import kgu.developers.domain.user.domain.User;
 import kgu.developers.domain.user.exception.DeptCodeNotValidException;
 import kgu.developers.domain.user.exception.EmailDomainNotValidException;
 import kgu.developers.domain.user.exception.InvalidPasswordException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static kgu.developers.domain.user.domain.Major.CSE;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UserDomainTest {
 	private User user;
@@ -26,6 +28,7 @@ public class UserDomainTest {
 	private static final String VALID_EMAIL = "valid@kgu.ac.kr";
 	private static final String PHONE = "010-1234-5678";
 	private static final Major MAJOR = CSE;
+	private static final PasswordEncoder PASSWORD_ENCODER = new BCryptPasswordEncoder();
 
 	@BeforeEach
 	public void init() {
@@ -33,7 +36,7 @@ public class UserDomainTest {
 	}
 
 	private User createTestUser(String id, String password, String email, Major major) {
-		return User.create(id, password, NAME, email, PHONE, major);
+		return User.create(id, password, NAME, email, PHONE, major, PASSWORD_ENCODER);
 	}
 
 	@Test
@@ -43,7 +46,7 @@ public class UserDomainTest {
 		// then
 		assertNotNull(user);
 		assertEquals(ID, user.getId());
-		assertEquals(PASSWORD, user.getPassword());
+		assertTrue(PASSWORD_ENCODER.matches(PASSWORD, user.getPassword()));
 		assertEquals(NAME, user.getName());
 		assertEquals(VALID_EMAIL, user.getEmail());
 		assertEquals(PHONE, user.getPhone());
@@ -115,9 +118,10 @@ public class UserDomainTest {
 		String newPassword = "newPassword";
 
 		// when
-		user.updatePassword(newPassword);
+		user.updatePassword(newPassword, PASSWORD_ENCODER);
 
 		// then
-		assertEquals(newPassword, user.getPassword());
+		assertTrue(PASSWORD_ENCODER.matches(newPassword, user.getPassword()));
+		assertFalse(PASSWORD_ENCODER.matches(PASSWORD, user.getPassword()));
 	}
 }

--- a/aics-domain/src/testFixtures/java/user/domain/UserDomainTest.java
+++ b/aics-domain/src/testFixtures/java/user/domain/UserDomainTest.java
@@ -107,4 +107,17 @@ public class UserDomainTest {
 		assertThatThrownBy(() -> user.updateEmail(null))
 			.isInstanceOf(EmailDomainNotValidException.class);
 	}
+
+	@Test
+	@DisplayName("updatePassword는 User의 password를 수정한다.")
+	public void updatePassword_Success() {
+		// given
+		String newPassword = "newPassword";
+
+		// when
+		user.updatePassword(newPassword);
+
+		// then
+		assertEquals(newPassword, user.getPassword());
+	}
 }


### PR DESCRIPTION
## Summary

>- #201 

회원 비밀번호 변경 기능 구현

## Tasks

- 회원 비밀번호 변경 기능을 도메인 로직으로 작성했습니다.
- 관련 비즈니스 로직을 Facade와 CommandService에 작성했습니다.
- 엔드포인트를 생성했습니다.
- 테스트 코드를 작성했습니다.
