### PR TITLE
refactor/#216 professor dto

### DIFF
--- a/aics-admin/src/main/java/kgu/developers/admin/professor/application/ProfessorAdminFacade.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/professor/application/ProfessorAdminFacade.java
@@ -1,5 +1,6 @@
 package kgu.developers.admin.professor.application;
 
+import kgu.developers.domain.professor.domain.Role;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,14 +19,14 @@ public class ProfessorAdminFacade {
 	private final ProfessorQueryService professorQueryService;
 
 	public ProfessorPersistResponse createProfessor(ProfessorRequest request) {
-		Long id = professorCommandService.createProfessor(request.name(), request.role(), request.contact(),
+		Long id = professorCommandService.createProfessor(request.name(), Role.of(request.role()), request.contact(),
 			request.email(), request.img(), request.officeLoc());
 		return ProfessorPersistResponse.of(id);
 	}
 
 	public void updateProfessor(Long id, ProfessorRequest request) {
 		Professor professor = professorQueryService.getProfessorById(id);
-		professorCommandService.updateProfessor(professor, request.name(), request.role(), request.contact(),
+		professorCommandService.updateProfessor(professor, request.name(), Role.of(request.role()), request.contact(),
 			request.email(), request.img(), request.officeLoc());
 	}
 

--- a/aics-admin/src/main/java/kgu/developers/admin/professor/presentation/request/ProfessorRequest.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/professor/presentation/request/ProfessorRequest.java
@@ -14,9 +14,9 @@ public record ProfessorRequest(
 	@NotNull
 	String name,
 
-	@Schema(description = "직위", example = "ASSISTANT", requiredMode = REQUIRED)
+	@Schema(description = "직위", example = "조교수", requiredMode = REQUIRED)
 	@NotNull
-	Role role,
+	String role,
 
 	@Schema(description = "연락처", example = "031-249-9671", requiredMode = REQUIRED)
 	@Pattern(regexp = "^\\d{2,4}-\\d{3,4}-\\d{4}$", message = "유효한 전화번호 형식이 아닙니다.")

--- a/aics-admin/src/main/java/kgu/developers/admin/professor/presentation/request/ProfessorRequest.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/professor/presentation/request/ProfessorRequest.java
@@ -1,12 +1,11 @@
 package kgu.developers.admin.professor.presentation.request;
 
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import kgu.developers.domain.professor.domain.Role;
 import lombok.Builder;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 @Builder
 public record ProfessorRequest(

--- a/aics-admin/src/testFixtures/java/professor/application/ProfessorAdminFacadeTest.java
+++ b/aics-admin/src/testFixtures/java/professor/application/ProfessorAdminFacadeTest.java
@@ -5,6 +5,7 @@ import static kgu.developers.domain.professor.domain.Role.PROFESSOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import kgu.developers.domain.professor.domain.Role;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ public class ProfessorAdminFacadeTest {
 		// given
 		ProfessorRequest request = ProfessorRequest.builder()
 			.name("권기현")
-			.role(PROFESSOR)
+			.role("교수")
 			.email("kkh1111@kgu.ac.kr")
 			.contact("010-1234-5678")
 			.img("kkhImg")
@@ -67,7 +68,7 @@ public class ProfessorAdminFacadeTest {
 		Long professorId = 1L;
 		ProfessorRequest request = ProfessorRequest.builder()
 			.name("권기현")
-			.role(PROFESSOR)
+			.role("교수")
 			.email("kkh1111@kgu.ac.kr")
 			.contact("010-1234-5678")
 			.img("kkhImg")
@@ -83,7 +84,7 @@ public class ProfessorAdminFacadeTest {
 		assertEquals(request.name(), professor.getName());
 		assertEquals(request.email(), professor.getEmail());
 		assertEquals(request.contact(), professor.getContact());
-		assertEquals(request.role(), professor.getRole());
+		assertEquals(Role.of(request.role()), professor.getRole());
 		assertEquals(request.img(), professor.getImg());
 		assertEquals(request.officeLoc(), professor.getOfficeLoc());
 	}

--- a/aics-admin/src/testFixtures/java/professor/application/ProfessorAdminFacadeTest.java
+++ b/aics-admin/src/testFixtures/java/professor/application/ProfessorAdminFacadeTest.java
@@ -1,22 +1,20 @@
 package professor.application;
 
-import static kgu.developers.domain.professor.domain.Role.ASSISTANT;
-import static kgu.developers.domain.professor.domain.Role.PROFESSOR;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-import kgu.developers.domain.professor.domain.Role;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import kgu.developers.admin.professor.application.ProfessorAdminFacade;
 import kgu.developers.admin.professor.presentation.request.ProfessorRequest;
 import kgu.developers.admin.professor.presentation.response.ProfessorPersistResponse;
 import kgu.developers.domain.professor.application.command.ProfessorCommandService;
 import kgu.developers.domain.professor.application.query.ProfessorQueryService;
 import kgu.developers.domain.professor.domain.Professor;
+import kgu.developers.domain.professor.domain.Role;
 import mock.repository.FakeProfessorRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static kgu.developers.domain.professor.domain.Role.ASSISTANT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ProfessorAdminFacadeTest {
 	private ProfessorAdminFacade professorAdminFacade;

--- a/aics-api/src/main/java/kgu/developers/api/professor/presentation/response/ProfessorListResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/professor/presentation/response/ProfessorListResponse.java
@@ -15,7 +15,7 @@ public record ProfessorListResponse(
 		example = "[{"
 			+ "\"id\": 1, "
 			+ "\"name\": \"이은정\", "
-			+ "\"type\": \"조교수\", "
+			+ "\"role\": \"조교수\", "
 			+ "\"contact\": \"031-249-9671\", "
 			+ "\"officeLoc\": \"8213호\", "
 			+ "\"email\": \"ejlee@kyonggi.ac.kr\", "

--- a/aics-api/src/testFixtures/java/professor/application/ProfessorFacadeTest.java
+++ b/aics-api/src/testFixtures/java/professor/application/ProfessorFacadeTest.java
@@ -62,7 +62,7 @@ public class ProfessorFacadeTest {
 
 		ProfessorResponse professor1 = professors.get(0);
 		assertEquals("권기현", professor1.name());
-		assertEquals(PROFESSOR.getDescription(), professor1.type());
+		assertEquals(PROFESSOR.getDescription(), professor1.role());
 		assertEquals("031-249-9666", professor1.contact());
 		assertEquals("http://cs.kyonggi.ac.kr:8080/img/professor/20180209095754-%EA%B6%8C%EA%B8%B0%ED%98%84.jpeg",
 			professor1.img());
@@ -70,7 +70,7 @@ public class ProfessorFacadeTest {
 
 		ProfessorResponse professor2 = professors.get(1);
 		assertEquals("임현기", professor2.name());
-		assertEquals(ASSISTANT.getDescription(), professor2.type());
+		assertEquals(ASSISTANT.getDescription(), professor2.role());
 		assertEquals("031-249-1318", professor2.contact());
 		assertEquals("http://cs.kyonggi.ac.kr:8080/img/professor/20210428143902-%EC%9C%A4%EC%9B%90%ED%98%84.jpg",
 			professor2.img());

--- a/aics-domain/src/main/java/kgu/developers/domain/professor/application/response/ProfessorResponse.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/professor/application/response/ProfessorResponse.java
@@ -15,7 +15,7 @@ public record ProfessorResponse(
 	String name,
 
 	@Schema(description = "직위", example = "조교수", requiredMode = REQUIRED)
-	String type,
+	String role,
 
 	@Schema(description = "연락처", example = "031-249-9671", requiredMode = REQUIRED)
 	String contact,
@@ -33,7 +33,7 @@ public record ProfessorResponse(
 		return ProfessorResponse.builder()
 			.id(professor.getId())
 			.name(professor.getName())
-			.type(professor.getRole().getDescription())
+			.role(professor.getRole().getDescription())
 			.contact(professor.getContact())
 			.officeLoc(professor.getOfficeLoc())
 			.email(professor.getEmail())

--- a/aics-domain/src/main/java/kgu/developers/domain/professor/domain/Role.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/professor/domain/Role.java
@@ -13,12 +13,10 @@ public enum Role {
 	private final String description;
 
 	public static Role of(String description) {
-		switch (description) {
-			case "교수":
-				return PROFESSOR;
-			case "조교수":
-				return ASSISTANT;
-		}
-		throw new NoSuchRoleException();
+		return switch (description) {
+			case "교수" -> PROFESSOR;
+			case "조교수" -> ASSISTANT;
+			default -> throw new NoSuchRoleException();
+		};
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/professor/domain/Role.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/professor/domain/Role.java
@@ -1,5 +1,6 @@
 package kgu.developers.domain.professor.domain;
 
+import kgu.developers.domain.professor.exception.NoSuchRoleException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,4 +11,14 @@ public enum Role {
 	ASSISTANT("조교수");
 
 	private final String description;
+
+	public static Role of(String description) {
+		switch (description) {
+			case "교수":
+				return PROFESSOR;
+			case "조교수":
+				return ASSISTANT;
+		}
+		throw new NoSuchRoleException();
+	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/professor/exception/NoSuchRoleException.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/professor/exception/NoSuchRoleException.java
@@ -1,0 +1,11 @@
+package kgu.developers.domain.professor.exception;
+
+import kgu.developers.common.exception.CustomException;
+
+import static kgu.developers.domain.professor.exception.ProfessorDomainExceptionCode.NO_SUCH_ROLE;
+
+public class NoSuchRoleException extends CustomException {
+	public NoSuchRoleException() {
+		super(NO_SUCH_ROLE);
+	}
+}

--- a/aics-domain/src/main/java/kgu/developers/domain/professor/exception/ProfessorDomainExceptionCode.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/professor/exception/ProfessorDomainExceptionCode.java
@@ -1,5 +1,6 @@
 package kgu.developers.domain.professor.exception;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import org.springframework.http.HttpStatus;
@@ -11,7 +12,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ProfessorDomainExceptionCode implements ExceptionCode {
-	PROFESSOR_NOT_FOUND(NOT_FOUND, "해당 교수를 찾을 수 없습니다.");
+	PROFESSOR_NOT_FOUND(NOT_FOUND, "해당 교수를 찾을 수 없습니다."),
+	NO_SUCH_ROLE(BAD_REQUEST, "role은 \"교수\" 혹은 \"조교수\"입니다."),
+	;
 
 	private final HttpStatus status;
 	private final String message;

--- a/aics-domain/src/testFixtures/java/professor/domain/RoleEnumTest.java
+++ b/aics-domain/src/testFixtures/java/professor/domain/RoleEnumTest.java
@@ -1,0 +1,42 @@
+package professor.domain;
+
+import kgu.developers.domain.professor.domain.Role;
+import kgu.developers.domain.professor.exception.NoSuchRoleException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class RoleEnumTest {
+
+	@Test
+	@DisplayName("Role은 description으로 생성할 수 있다")
+	public void of_Success() {
+		// given
+		String description1 = "교수";
+		String description2 = "조교수";
+
+		// when
+		Role role1 = Role.of(description1);
+		Role role2 = Role.of(description2);
+
+		// then
+		assertEquals("PROFESSOR", role1.name());
+		assertEquals("ASSISTANT", role2.name());
+		assertEquals(description1, role1.getDescription());
+		assertEquals(description2, role2.getDescription());
+	}
+
+
+	@Test
+	@DisplayName("Role은 description이 올바르지 않으면 NoSuchRoleException을 반환한다")
+	public void of_throws_NoSuchRoleException() {
+		// given
+		String description = "학생";
+
+		// when
+		// then
+		assertThrows(NoSuchRoleException.class, () -> Role.of(description));
+	}
+}


### PR DESCRIPTION
## Summary

>- #216 
교수 DTO의 변수명을 통일하고, 입력시 한글로 받도록 작업했습니다.

## Tasks

- ProfessorResponse 의 type을 role로 변경
- ProfessorRequest 의 Role을 String인 교수, 조교수로 받도록 변경

## To Reviewers 

- 한글로 입력을 받다보니 Role Enum 타입에서 String으로 변경했습니다.
  또 사용자의 입력을 통해 Role을 생성하려다보니 Enum에 정적 팩토리 메소드를 추가했는데 올바른 구현인지 궁금합니다.

## Screenshot
- 조회 
![스크린샷 2025-03-07 오후 10 17 00](https://github.com/user-attachments/assets/d26f9819-68f9-4460-956f-b4bbcc25d039)

- 생성
![스크린샷 2025-03-07 오후 10 17 16](https://github.com/user-attachments/assets/f6d322c6-e1ea-4e46-a1a4-1c186e96b8e4)

