### PR TITLE
refactor/#232 소개글 수정 API 카테고리를 전달받도록 변경

### DIFF
--- a/aics-admin/src/main/java/kgu/developers/admin/about/application/AboutAdminFacade.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/about/application/AboutAdminFacade.java
@@ -1,5 +1,6 @@
 package kgu.developers.admin.about.application;
 
+import kgu.developers.domain.about.domain.Category;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +21,7 @@ public class AboutAdminFacade {
 		return AboutPersistResponse.of(id);
 	}
 
-	public void updateAbout(Long id, AboutUpdateRequest request) {
-		aboutCommandService.updateAbout(id, request.content());
+	public void updateAbout(Category category, AboutUpdateRequest request) {
+		aboutCommandService.updateAbout(category, request.content());
 	}
 }

--- a/aics-admin/src/main/java/kgu/developers/admin/about/presentation/AboutAdminController.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/about/presentation/AboutAdminController.java
@@ -1,5 +1,6 @@
 package kgu.developers.admin.about.presentation;
 
+import kgu.developers.domain.about.domain.Category;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +16,7 @@ import jakarta.validation.constraints.Positive;
 import kgu.developers.admin.about.presentation.request.AboutCreateRequest;
 import kgu.developers.admin.about.presentation.request.AboutUpdateRequest;
 import kgu.developers.admin.about.presentation.response.AboutPersistResponse;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "About", description = "소개글 관리자 API")
 public interface AboutAdminController {
@@ -40,10 +42,10 @@ public interface AboutAdminController {
 	@ApiResponse(responseCode = "204")
 	ResponseEntity<Void> updateAbout(
 		@Parameter(
-			description = "소개글 ID는 URL 경로 변수 입니다.",
-			example = "1",
+			description = "카테고리 ENUM 타입 입니다.",
+			example = "DEPT_INTRO",
 			required = true
-		) @Positive @PathVariable Long id,
+		) @RequestParam(name = "category") Category category,
 		@Parameter(
 			description = "소개글 수정 request 객체 입니다.",
 			required = true

--- a/aics-admin/src/main/java/kgu/developers/admin/about/presentation/AboutAdminController.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/about/presentation/AboutAdminController.java
@@ -2,7 +2,6 @@ package kgu.developers.admin.about.presentation;
 
 import kgu.developers.domain.about.domain.Category;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,7 +11,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Positive;
 import kgu.developers.admin.about.presentation.request.AboutCreateRequest;
 import kgu.developers.admin.about.presentation.request.AboutUpdateRequest;
 import kgu.developers.admin.about.presentation.response.AboutPersistResponse;

--- a/aics-admin/src/main/java/kgu/developers/admin/about/presentation/AboutAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/about/presentation/AboutAdminControllerImpl.java
@@ -3,6 +3,7 @@ package kgu.developers.admin.about.presentation;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
+import kgu.developers.domain.about.domain.Category;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
@@ -37,12 +39,12 @@ public class AboutAdminControllerImpl implements AboutAdminController {
 	}
 
 	@Override
-	@PatchMapping("/{id}")
+	@PatchMapping
 	public ResponseEntity<Void> updateAbout(
-		@Positive @PathVariable Long id,
+		@RequestParam Category category,
 		@Valid @RequestBody AboutUpdateRequest request
 	) {
-		aboutAdminFacade.updateAbout(id, request);
+		aboutAdminFacade.updateAbout(category, request);
 		return ResponseEntity.status(NO_CONTENT).build();
 	}
 }

--- a/aics-admin/src/main/java/kgu/developers/admin/about/presentation/AboutAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/about/presentation/AboutAdminControllerImpl.java
@@ -7,7 +7,6 @@ import kgu.developers.domain.about.domain.Category;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,7 +14,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Positive;
 import kgu.developers.admin.about.application.AboutAdminFacade;
 import kgu.developers.admin.about.presentation.request.AboutCreateRequest;
 import kgu.developers.admin.about.presentation.request.AboutUpdateRequest;

--- a/aics-admin/src/main/java/kgu/developers/admin/about/presentation/request/AboutCreateRequest.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/about/presentation/request/AboutCreateRequest.java
@@ -13,7 +13,7 @@ public record AboutCreateRequest(
 	@NotNull
 	Category category,
 
-	@Schema(description = "페이지 내용(JSON 형식)", example = "{key:value}", requiredMode = REQUIRED)
+	@Schema(description = "페이지 내용", example = "학과 소개 내용입니다.", requiredMode = REQUIRED)
 	@NotNull
 	String content
 ) {

--- a/aics-admin/src/main/java/kgu/developers/admin/about/presentation/request/AboutUpdateRequest.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/about/presentation/request/AboutUpdateRequest.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 
 @Builder
 public record AboutUpdateRequest(
-	@Schema(description = "페이지 내용(JSON 형식)", example = "{key:value}", requiredMode = REQUIRED)
+	@Schema(description = "페이지 내용", example = "학과 소개 내용입니다.", requiredMode = REQUIRED)
 	@NotNull
 	String content
 ) {

--- a/aics-admin/src/testFixtures/java/about/application/AboutAdminFacadeTest.java
+++ b/aics-admin/src/testFixtures/java/about/application/AboutAdminFacadeTest.java
@@ -1,6 +1,7 @@
 package about.application;
 
 import static kgu.developers.domain.about.domain.Category.DEPT_INTRO;
+import static kgu.developers.domain.about.domain.Category.DIRECTIONS;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -58,17 +59,17 @@ public class AboutAdminFacadeTest {
 	@DisplayName("updateAbout은 About의 content를 수정한다")
 	public void updateAbout_Success() {
 		// given
-		Long id = 1L;
+		Category category = DEPT_INTRO;
 
 		AboutUpdateRequest request = AboutUpdateRequest.builder()
 			.content("updateContent")
 			.build();
 
 		// when
-		aboutAdminFacade.updateAbout(id, request);
+		aboutAdminFacade.updateAbout(category, request);
 
 		// then
-		About about = fakeAboutRepository.findById(id).orElseThrow();
+		About about = fakeAboutRepository.findByCategory(category).orElseThrow();
 		assertEquals(request.content(), about.getContent());
 	}
 
@@ -76,7 +77,7 @@ public class AboutAdminFacadeTest {
 	@DisplayName("updateAbout은 존재하지 않는 id로 수정 요청 시 AboutNotFoundException을 발생시킨다")
 	public void updateAbout_AboutNotFound_ThrowsException() {
 		// given
-		Long id = 0L;
+		Category category = DIRECTIONS;
 
 		AboutUpdateRequest request = AboutUpdateRequest.builder()
 			.content("updateContent")
@@ -84,7 +85,7 @@ public class AboutAdminFacadeTest {
 
 		// when
 		// then
-		assertThatThrownBy(() -> aboutAdminFacade.updateAbout(id, request))
+		assertThatThrownBy(() -> aboutAdminFacade.updateAbout(category, request))
 			.isInstanceOf(AboutNotFoundException.class);
 	}
 }

--- a/aics-admin/src/testFixtures/java/about/application/AboutAdminFacadeTest.java
+++ b/aics-admin/src/testFixtures/java/about/application/AboutAdminFacadeTest.java
@@ -40,11 +40,9 @@ public class AboutAdminFacadeTest {
 	@DisplayName("createAbout은 about을 생성한다")
 	public void createAbout_Success() {
 		// given
-		Category category = DEPT_INTRO;
 		String content = "content";
-
 		AboutCreateRequest request = AboutCreateRequest.builder()
-			.category(category)
+			.category(DEPT_INTRO)
 			.content(content)
 			.build();
 
@@ -77,15 +75,13 @@ public class AboutAdminFacadeTest {
 	@DisplayName("updateAbout은 존재하지 않는 id로 수정 요청 시 AboutNotFoundException을 발생시킨다")
 	public void updateAbout_AboutNotFound_ThrowsException() {
 		// given
-		Category category = DIRECTIONS;
-
 		AboutUpdateRequest request = AboutUpdateRequest.builder()
 			.content("updateContent")
 			.build();
 
 		// when
 		// then
-		assertThatThrownBy(() -> aboutAdminFacade.updateAbout(category, request))
+		assertThatThrownBy(() -> aboutAdminFacade.updateAbout(DIRECTIONS, request))
 			.isInstanceOf(AboutNotFoundException.class);
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/about/presentation/response/AboutResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/about/presentation/response/AboutResponse.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 
 @Builder
 public record AboutResponse(
-	@Schema(description = "페이지 내용(JSON 형식)", example = "{key:value}", requiredMode = REQUIRED)
+	@Schema(description = "페이지 내용", example = "학과 소개 내용입니다.", requiredMode = REQUIRED)
 	String content
 ) {
 	public static AboutResponse from(About about) {

--- a/aics-domain/src/main/java/kgu/developers/domain/about/application/command/AboutCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/about/application/command/AboutCommandService.java
@@ -18,8 +18,8 @@ public class AboutCommandService {
 		return aboutRepository.save(about).getId();
 	}
 
-	public void updateAbout(Long id, String content) {
-		About about = aboutRepository.findById(id)
+	public void updateAbout(Category category, String content) {
+		About about = aboutRepository.findByCategory(category)
 			.orElseThrow(AboutNotFoundException::new);
 		about.updateContent(content);
 	}

--- a/aics-domain/src/testFixtures/java/about/application/AboutCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/about/application/AboutCommandServiceTest.java
@@ -34,11 +34,10 @@ public class AboutCommandServiceTest {
 	@DisplayName("createAbout은 About 객체를 생성한다")
 	public void createAbout_Success() {
 		// given
-		Category category = DEPT_INTRO;
 		String content = "test content";
 
 		// when
-		Long result = aboutCommandService.createAbout(category, content);
+		Long result = aboutCommandService.createAbout(DEPT_INTRO, content);
 
 		// then
 		assertEquals(2L, result);
@@ -66,12 +65,11 @@ public class AboutCommandServiceTest {
 	@DisplayName("updateAbout은 존재하지 않는 about 수정 요청 시 AboutNotFoundException을 발생시킨다")
 	public void updateAbout_Throws_AboutNotFoundException() {
 		// given
-		Category category = DIRECTIONS;
 		String newContent = "update content";
 
 		// when
 		// then
-		assertThatThrownBy(() -> aboutCommandService.updateAbout(category, newContent))
+		assertThatThrownBy(() -> aboutCommandService.updateAbout(DIRECTIONS, newContent))
 			.isInstanceOf(AboutNotFoundException.class);
 	}
 }

--- a/aics-domain/src/testFixtures/java/about/application/AboutCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/about/application/AboutCommandServiceTest.java
@@ -1,6 +1,7 @@
 package about.application;
 
 import static kgu.developers.domain.about.domain.Category.DEPT_INTRO;
+import static kgu.developers.domain.about.domain.Category.DIRECTIONS;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -47,17 +48,17 @@ public class AboutCommandServiceTest {
 	@DisplayName("updateAbout은 About을 수정할 수 있다")
 	public void updateAbout_Success() {
 		// given
-		Long aboutId = 1L;
+		Category category = DEPT_INTRO;
 		String newContent = "update content";
 
 		// when
-		aboutCommandService.updateAbout(aboutId, newContent);
+		aboutCommandService.updateAbout(category, newContent);
 
 		// then
-		About about = fakeAboutRepository.findById(aboutId).orElse(null);
+		About about = fakeAboutRepository.findByCategory(category).orElse(null);
 
 		assertNotNull(about);
-		assertEquals(aboutId, about.getId());
+		assertEquals(category, about.getCategory());
 		assertEquals(newContent, about.getContent());
 	}
 
@@ -65,12 +66,12 @@ public class AboutCommandServiceTest {
 	@DisplayName("updateAbout은 존재하지 않는 about 수정 요청 시 AboutNotFoundException을 발생시킨다")
 	public void updateAbout_Throws_AboutNotFoundException() {
 		// given
-		Long aboutId = 3L;
+		Category category = DIRECTIONS;
 		String newContent = "update content";
 
 		// when
 		// then
-		assertThatThrownBy(() -> aboutCommandService.updateAbout(aboutId, newContent))
+		assertThatThrownBy(() -> aboutCommandService.updateAbout(category, newContent))
 			.isInstanceOf(AboutNotFoundException.class);
 	}
 }


### PR DESCRIPTION
## Summary

>- #232 

**해당 PR에 대한 요약을 작성해주세요.**
소개글 수정 API에서 ID가 아닌 카테고리를 전달받도록 변경했습니다.

## Tasks

- AboutAdminController의 파라미터를 변경했습니다.
- 관련 비즈니스 로직을 변경했습니다.
- 소개글을 스웨거에서 JSON 타입이 아닌 일반 텍스트임을 명시하도록 변경했습니다.

## Screenshot
![스크린샷 2025-04-15 오후 10 13 11](https://github.com/user-attachments/assets/ad5fdde8-9fb0-4a3c-9324-e30d83119569)



