### PR TITLE
chore/#243 운영 배포를 위한 스테이징 환경 구축 및 스크립트 구성

### DIFF
--- a/.github/workflows/staging-build-deploy.yml
+++ b/.github/workflows/staging-build-deploy.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/staging-build-deploy.yml
+++ b/.github/workflows/staging-build-deploy.yml
@@ -41,7 +41,7 @@ jobs:
           docker save aics-auth:${GITHUB_SHA} -o deploy/aics-auth.tar
 
       - name: Upload Docker images to server
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action@v1.0.0
         with:
           host: ${{ secrets.STAGING_SERVER_HOST }}
           username: ${{ secrets.STAGING_SERVER_USERNAME }}

--- a/.github/workflows/staging-build-deploy.yml
+++ b/.github/workflows/staging-build-deploy.yml
@@ -1,0 +1,63 @@
+name: Build and Deploy to Staging Server
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: staging
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build all modules
+        run: |
+          ./gradlew clean build -p aics-admin -x test
+          ./gradlew clean build -p aics-api -x test
+          ./gradlew clean build -p aics-auth -x test
+
+      - name: Build Docker images
+        run: |
+          docker build -t aics-admin:${GITHUB_SHA} -f aics-admin/Dockerfile aics-admin
+          docker build -t aics-api:${GITHUB_SHA} -f aics-api/Dockerfile aics-api
+          docker build -t aics-auth:${GITHUB_SHA} -f aics-auth/Dockerfile aics-auth
+
+      - name: Save Docker images as tar
+        run: |
+          mkdir -p deploy
+          docker save aics-admin:${GITHUB_SHA} -o deploy/aics-admin.tar
+          docker save aics-api:${GITHUB_SHA} -o deploy/aics-api.tar
+          docker save aics-auth:${GITHUB_SHA} -o deploy/aics-auth.tar
+
+      - name: Upload Docker images to server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.STAGING_SERVER_HOST }}
+          username: ${{ secrets.STAGING_SERVER_USERNAME }}
+          password: ${{ secrets.STAGING_SERVER_PASSWORD }}
+          port: ${{ secrets.STAGING_SERVER_PORT }}
+          source: "deploy/*"
+          target: ${{ secrets.STAGING_DEPLOY_PATH }}
+
+      - name: Deploy on server
+        uses: appleboy/ssh-action@v1.1.0
+        with:
+          host: ${{ secrets.STAGING_SERVER_HOST }}
+          username: ${{ secrets.STAGING_SERVER_USERNAME }}
+          password: ${{ secrets.STAGING_SERVER_PASSWORD }}
+          port: ${{ secrets.STAGING_SERVER_PORT }}
+          script: |
+            cd ${{ secrets.STAGING_DEPLOY_PATH }}
+            chmod +x backend/deploy.sh
+            ./backend/deploy.sh

--- a/aics-admin/src/main/java/kgu/developers/admin/about/presentation/AboutAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/about/presentation/AboutAdminControllerImpl.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/abouts")
+@RequestMapping("/api/v1/admin/abouts")
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 public class AboutAdminControllerImpl implements AboutAdminController {
 	private final AboutAdminFacade aboutAdminFacade;

--- a/aics-admin/src/main/java/kgu/developers/admin/carousel/presentation/CarouselAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/carousel/presentation/CarouselAdminControllerImpl.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/carousels")
+@RequestMapping("/api/v1/admin/carousels")
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 public class CarouselAdminControllerImpl implements CarouselAdminController {
 	private final CarouselAdminFacade carouselAdminFacade;

--- a/aics-admin/src/main/java/kgu/developers/admin/club/presentation/ClubAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/club/presentation/ClubAdminControllerImpl.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/clubs")
+@RequestMapping("/api/v1/admin/clubs")
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 public class ClubAdminControllerImpl implements ClubAdminController {
 	private final ClubAdminFacade clubAdminFacade;

--- a/aics-admin/src/main/java/kgu/developers/admin/comment/presentation/CommentAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/comment/presentation/CommentAdminControllerImpl.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/comments")
+@RequestMapping("/api/v1/admin/comments")
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 public class CommentAdminControllerImpl implements CommentAdminController {
 	private final CommentAdminFacade commentAdminFacade;

--- a/aics-admin/src/main/java/kgu/developers/admin/file/presentation/FileAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/file/presentation/FileAdminControllerImpl.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/files")
+@RequestMapping("/api/v1/admin/files")
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 public class FileAdminControllerImpl implements FileAdminController {
 	private final FileAdminFacade fileAdminFacade;

--- a/aics-admin/src/main/java/kgu/developers/admin/lab/presentation/LabAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/lab/presentation/LabAdminControllerImpl.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/labs")
+@RequestMapping("/api/v1/admin/labs")
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 public class LabAdminControllerImpl implements LabAdminController{
 	private final LabAdminFacade labAdminFacade;

--- a/aics-admin/src/main/java/kgu/developers/admin/post/presentation/PostAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/post/presentation/PostAdminControllerImpl.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/posts")
+@RequestMapping("/api/v1/admin/posts")
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 public class PostAdminControllerImpl implements PostAdminController {
 	private final PostAdminFacade postAdminFacade;

--- a/aics-admin/src/main/java/kgu/developers/admin/professor/presentation/ProfessorAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/professor/presentation/ProfessorAdminControllerImpl.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/professors")
+@RequestMapping("/api/v1/admin/professors")
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 public class ProfessorAdminControllerImpl implements ProfessorAdminController {
 	private final ProfessorAdminFacade professorAdminFacade;

--- a/aics-admin/src/main/java/kgu/developers/admin/user/presentation/UserAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/user/presentation/UserAdminControllerImpl.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/users")
+@RequestMapping("/api/v1/admin/users")
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 public class UserAdminControllerImpl implements UserAdminController {
 	private final UserAdminFacade userAdminFacade;

--- a/aics-admin/src/main/resources/application-prod.yml
+++ b/aics-admin/src/main/resources/application-prod.yml
@@ -13,3 +13,9 @@ spring:
       host: ${REDIS_HOST:redis}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
+
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false

--- a/aics-api/src/main/resources/application-prod.yml
+++ b/aics-api/src/main/resources/application-prod.yml
@@ -13,3 +13,9 @@ spring:
       host: ${REDIS_HOST:redis}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
+
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false

--- a/aics-auth/src/main/resources/application-prod.yml
+++ b/aics-auth/src/main/resources/application-prod.yml
@@ -13,3 +13,9 @@ spring:
       host: ${REDIS_HOST:redis}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
+
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false

--- a/deploy/staging/deploy.sh
+++ b/deploy/staging/deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+APP_HOME=$(pwd)/backend
+
+echo "===== Loading Docker images ====="
+sudo docker load -i $APP_HOME/tar/aics-api.tar
+sudo docker load -i $APP_HOME/tar/aics-admin.tar
+sudo docker load -i $APP_HOME/tar/aics-auth.tar
+
+echo "===== Stopping existing containers ====="
+sudo docker compose -f $APP_HOME/docker-compose.yml down || true
+
+echo "===== Starting containers ====="
+sudo docker compose -f $APP_HOME/docker-compose.yml --env-file $APP_HOME/.env up -d
+
+echo "===== Deployment finished ====="

--- a/deploy/staging/deploy.sh
+++ b/deploy/staging/deploy.sh
@@ -5,8 +5,11 @@ APP_HOME=$(pwd)/backend
 
 echo "===== Loading Docker images ====="
 sudo docker load -i $APP_HOME/tar/aics-api.tar
+sudo docker tag aics-admin:${GITHUB_SHA} aics-admin:latest
 sudo docker load -i $APP_HOME/tar/aics-admin.tar
+sudo docker tag aics-auth:${GITHUB_SHA} aics-auth:latest
 sudo docker load -i $APP_HOME/tar/aics-auth.tar
+sudo docker tag aics-api:${GITHUB_SHA} aics-api:latest
 
 echo "===== Stopping existing containers ====="
 sudo docker compose -f $APP_HOME/docker-compose.yml down || true

--- a/docker/staging/docker-compose-db.yml
+++ b/docker/staging/docker-compose-db.yml
@@ -1,0 +1,4 @@
+include:
+  - networks.yml
+  - service-postgres.yml
+  - service-redis.yml

--- a/docker/staging/docker-compose.yml
+++ b/docker/staging/docker-compose.yml
@@ -1,0 +1,4 @@
+include:
+  - networks.yml
+  - service-application.yml
+  - service-nginx.yml

--- a/docker/staging/networks.yml
+++ b/docker/staging/networks.yml
@@ -1,0 +1,3 @@
+networks:
+  aics-network:
+    driver: bridge

--- a/docker/staging/service/service-application.yml
+++ b/docker/staging/service/service-application.yml
@@ -2,8 +2,6 @@ services:
   aics-api:
     image: aics-api:latest
     container_name: aics-api
-    ports:
-      - "8080:8080"
     env_file:
       - .env
     environment:
@@ -24,8 +22,6 @@ services:
   aics-admin:
     image: aics-admin:latest
     container_name: aics-admin
-    ports:
-      - "8081:8081"
     env_file:
       - .env
     environment:
@@ -46,8 +42,6 @@ services:
   aics-auth:
     image: aics-auth:latest
     container_name: aics-auth
-    ports:
-      - "8082:8082"
     env_file:
       - .env
     environment:

--- a/docker/staging/service/service-application.yml
+++ b/docker/staging/service/service-application.yml
@@ -1,6 +1,6 @@
 services:
   aics-api:
-    image: ${DOCKER_USERNAME}/aics-api:latest
+    image: aics-api:latest
     container_name: aics-api
     ports:
       - "8080:8080"
@@ -22,7 +22,7 @@ services:
       - aics-network
 
   aics-admin:
-    image: ${DOCKER_USERNAME}/aics-admin:latest
+    image: aics-admin:latest
     container_name: aics-admin
     ports:
       - "8081:8081"
@@ -44,7 +44,7 @@ services:
       - aics-network
 
   aics-auth:
-    image: ${DOCKER_USERNAME}/aics-auth:latest
+    image: aics-auth:latest
     container_name: aics-auth
     ports:
       - "8082:8082"

--- a/docker/staging/service/service-application.yml
+++ b/docker/staging/service/service-application.yml
@@ -1,0 +1,66 @@
+services:
+  aics-api:
+    image: ${DOCKER_USERNAME}/aics-api:latest
+    container_name: aics-api
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_NAME: ${POSTGRES_DB}
+      DB_USERNAME: ${POSTGRES_USER}
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
+      JWT_ISSUER: kgudevelopers@gmail.com
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      REDIS_HOST: redis
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      FILE_SECRET_KEY: ${FILE_SECRET_KEY}
+    networks:
+      - aics-network
+
+  aics-admin:
+    image: ${DOCKER_USERNAME}/aics-admin:latest
+    container_name: aics-admin
+    ports:
+      - "8081:8081"
+    env_file:
+      - .env
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_NAME: ${POSTGRES_DB}
+      DB_USERNAME: ${POSTGRES_USER}
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
+      JWT_ISSUER: kgudevelopers@gmail.com
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      REDIS_HOST: redis
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      FILE_SECRET_KEY: ${FILE_SECRET_KEY}
+    networks:
+      - aics-network
+
+  aics-auth:
+    image: ${DOCKER_USERNAME}/aics-auth:latest
+    container_name: aics-auth
+    ports:
+      - "8082:8082"
+    env_file:
+      - .env
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_NAME: ${POSTGRES_DB}
+      DB_USERNAME: ${POSTGRES_USER}
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
+      JWT_ISSUER: kgudevelopers@gmail.com
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      REDIS_HOST: redis
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      FILE_SECRET_KEY: ${FILE_SECRET_KEY}
+    networks:
+      - aics-network

--- a/docker/staging/service/service-nginx.yml
+++ b/docker/staging/service/service-nginx.yml
@@ -1,0 +1,9 @@
+services:
+  nginx:
+    image: nginx:latest
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+    ports:
+      - "80:80"
+    networks:
+      - aics-network

--- a/docker/staging/service/service-postgres.yml
+++ b/docker/staging/service/service-postgres.yml
@@ -1,0 +1,18 @@
+services:
+  postgres:
+    image: postgres:15
+    container_name: postgres
+    restart: always
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - aics-network
+
+volumes:
+  postgres-data:

--- a/docker/staging/service/service-postgres.yml
+++ b/docker/staging/service/service-postgres.yml
@@ -3,6 +3,8 @@ services:
     image: postgres:15
     container_name: postgres
     restart: always
+    env_file:
+      - .env
     ports:
       - "5432:5432"
     environment:

--- a/docker/staging/service/service-redis.yml
+++ b/docker/staging/service/service-redis.yml
@@ -4,6 +4,8 @@ services:
     container_name: redis
     restart: always
     command: redis-server
+    env_file:
+      - .env
     ports:
       - "6379:6379"
     environment:

--- a/docker/staging/service/service-redis.yml
+++ b/docker/staging/service/service-redis.yml
@@ -3,11 +3,9 @@ services:
     image: redis:latest
     container_name: redis
     restart: always
-    command: redis-server
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]
     env_file:
       - .env
-    ports:
-      - "6379:6379"
     environment:
       REDIS_PASSWORD: ${REDIS_PASSWORD}
     networks:

--- a/docker/staging/service/service-redis.yml
+++ b/docker/staging/service/service-redis.yml
@@ -1,0 +1,12 @@
+services:
+  redis:
+    image: redis:latest
+    container_name: redis
+    restart: always
+    command: redis-server
+    ports:
+      - "6379:6379"
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+    networks:
+      - aics-network

--- a/nginx/staging/nginx.conf
+++ b/nginx/staging/nginx.conf
@@ -1,0 +1,33 @@
+server {
+    listen 80;
+
+    location ^~ /api/v1/auth/ {
+        proxy_pass http://aics-auth:8082/api/v1/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Origin $http_origin;
+    }
+
+    location ^~ /api/v1/admin/ {
+        proxy_pass http://aics-admin:8081/api/v1/admin/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Origin $http_origin;
+    }
+
+    location ^~ /api/v1/ {
+        proxy_pass http://aics-api:8080/api/v1/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Origin $http_origin;
+    }
+
+    location / {
+        proxy_pass http://aics-app:3000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}


### PR DESCRIPTION
## Summary

>- #243

폐쇄망으로 구축된 운영 환경에서 원활한 배포를 위해 스테이징 환경을 유사하게 구축하였습니다.
GitHub Actions와 scp 기반으로 docker image를 압축하여 복사하며, 별도의 deploy 셸 스크립트를 통해 컨테이너를 구동합니다.

## Tasks

- 스테이징 환경 구성
- admin 엔드포인트 프리픽스를 추가하여, Nginx가 어드민 서비스에 대해 정상적으로 리버스 프록시를 수행하도록 구성
- docker compose yml 파일 및 deploy.sh 작성 

## To Reviewer

보안 상 중요한 파일은 노션에 추가하였습니다
