### PR TITLE
refactor/#257 Carousel, FileEntity간 ID 참조 방식으로 관계 매핑 변경

### DIFF
--- a/aics-admin/src/main/java/kgu/developers/admin/carousel/application/CarouselAdminFacade.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/carousel/application/CarouselAdminFacade.java
@@ -12,18 +12,17 @@ import kgu.developers.domain.carousel.domain.Carousel;
 import lombok.RequiredArgsConstructor;
 
 @Component
+@Transactional
 @RequiredArgsConstructor
 public class CarouselAdminFacade {
 	private final CarouselCommandService carouselCommandService;
 	private final CarouselQueryService carouselQueryService;
 
-	@Transactional
 	public CarouselPersistResponse createCarousel(Long fileId, CarouselRequest request) {
 		Long id = carouselCommandService.createCarousel(fileId, request.text(), request.link());
 		return CarouselPersistResponse.of(id);
 	}
 
-	@Transactional
 	public void updateCarousel(Long id, CarouselUpdateRequest request) {
 		Carousel carousel = carouselQueryService.getById(id);
 		carouselCommandService.updateCarousel(carousel, request.link(), request.text(), request.fileId());

--- a/aics-admin/src/testFixtures/java/carousel/application/CarouselAdminFacadeTest.java
+++ b/aics-admin/src/testFixtures/java/carousel/application/CarouselAdminFacadeTest.java
@@ -25,7 +25,6 @@ public class CarouselAdminFacadeTest {
 	private Carousel carousel;
 
 	private static final Long TEST_FILE_ID = 1L;
-	private static final Long SAVE_TARGET_ID = 1L;
 
 	@BeforeEach
 	public void init() {
@@ -83,7 +82,7 @@ public class CarouselAdminFacadeTest {
 		// then
 		assertEquals(request.text(), carousel.getText());
 		assertEquals(request.link(), carousel.getLink());
-		assertEquals(request.fileId(), carousel.getFile().getId());
+		assertEquals(request.fileId(), carousel.getFileId());
 	}
 
 	@Test

--- a/aics-api/src/main/java/kgu/developers/api/carousel/application/CarouselFacade.java
+++ b/aics-api/src/main/java/kgu/developers/api/carousel/application/CarouselFacade.java
@@ -5,17 +5,27 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import kgu.developers.api.carousel.presentation.response.CarouselListResponse;
+import kgu.developers.api.carousel.presentation.response.CarouselResponse;
 import kgu.developers.domain.carousel.application.query.CarouselQueryService;
-import kgu.developers.domain.carousel.domain.Carousel;
+import kgu.developers.domain.file.application.query.FileQueryService;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class CarouselFacade {
 	private final CarouselQueryService carouselQueryService;
+	private final FileQueryService fileQueryService;
 
 	public CarouselListResponse getCarousels() {
-		List<Carousel> carousels = carouselQueryService.getAllCarousels();
+		List<CarouselResponse> carousels = carouselQueryService.getAllCarousels()
+			.stream()
+			.map(carousel -> {
+				String filePath = fileQueryService.getFilePhysicalPath(carousel.getFileId());
+				return CarouselResponse.of(carousel, filePath);
+			})
+			.toList();
+
 		return CarouselListResponse.from(carousels);
 	}
 }
+

--- a/aics-api/src/main/java/kgu/developers/api/carousel/application/CarouselFacade.java
+++ b/aics-api/src/main/java/kgu/developers/api/carousel/application/CarouselFacade.java
@@ -20,7 +20,8 @@ public class CarouselFacade {
 		List<CarouselResponse> carousels = carouselQueryService.getAllCarousels()
 			.stream()
 			.map(carousel -> {
-				String filePath = fileQueryService.getFilePhysicalPath(carousel.getFileId());
+				Long fileId = carousel.getFileId();
+				String filePath = (fileId != null) ? fileQueryService.getFilePhysicalPath(fileId) : null;
 				return CarouselResponse.of(carousel, filePath);
 			})
 			.toList();

--- a/aics-api/src/main/java/kgu/developers/api/carousel/presentation/response/CarouselListResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/carousel/presentation/response/CarouselListResponse.java
@@ -5,7 +5,6 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import kgu.developers.domain.carousel.domain.Carousel;
 import lombok.Builder;
 
 @Builder
@@ -25,11 +24,9 @@ public record CarouselListResponse(
 		requiredMode = REQUIRED)
 	List<CarouselResponse> contents
 ) {
-	public static CarouselListResponse from(List<Carousel> carousels) {
+	public static CarouselListResponse from(List<CarouselResponse> carousels) {
 		return CarouselListResponse.builder()
-			.contents(carousels.stream()
-				.map(CarouselResponse::from)
-				.toList())
+			.contents(carousels)
 			.build();
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/carousel/presentation/response/CarouselResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/carousel/presentation/response/CarouselResponse.java
@@ -25,12 +25,12 @@ public record CarouselResponse(
 		requiredMode = NOT_REQUIRED)
 	FilePathResponse file
 ) {
-	public static CarouselResponse from(Carousel carousel) {
+	public static CarouselResponse of(Carousel carousel, String physicalPath) {
 		return CarouselResponse.builder()
 			.id(carousel.getId())
 			.text(carousel.getText())
 			.link(carousel.getLink())
-			.file(carousel.getFile() != null ? FilePathResponse.from(carousel.getFile()) : null)
+			.file(carousel.getFileId() != null ? FilePathResponse.of(carousel.getFileId(), physicalPath) : null)
 			.build();
 	}
 }

--- a/aics-api/src/testFixtures/java/carousel/application/CarouselFacadeTest.java
+++ b/aics-api/src/testFixtures/java/carousel/application/CarouselFacadeTest.java
@@ -10,13 +10,16 @@ import kgu.developers.api.carousel.application.CarouselFacade;
 import kgu.developers.api.carousel.presentation.response.CarouselListResponse;
 import kgu.developers.domain.carousel.application.query.CarouselQueryService;
 import kgu.developers.domain.carousel.domain.Carousel;
+import kgu.developers.domain.file.application.query.FileQueryService;
 import kgu.developers.domain.file.domain.FileEntity;
 import mock.repository.FakeCarouselRepository;
+import mock.repository.FakeFileRepository;
 
 public class CarouselFacadeTest {
 	private CarouselFacade carouselFacade;
 
 	private static final int TARGET_CAROUSEL_SIZE = 2;
+	private static final Long FAKE_FILE_ID = 1L;
 
 	@BeforeEach
 	public void init() {
@@ -25,19 +28,21 @@ public class CarouselFacadeTest {
 
 	private void initializeCarouselFacade() {
 		FakeCarouselRepository fakeCarouselRepository = new FakeCarouselRepository();
+		FakeFileRepository fakeFileRepository = new FakeFileRepository();
 		carouselFacade = new CarouselFacade(
-			new CarouselQueryService(fakeCarouselRepository)
+			new CarouselQueryService(fakeCarouselRepository),
+			new FileQueryService(fakeFileRepository)
 		);
 		saveTestCarousel(fakeCarouselRepository);
 	}
 
 	private static void saveTestCarousel(FakeCarouselRepository fakeCarouselRepository) {
 		fakeCarouselRepository.save(
-			Carousel.create("컴퓨터공학부 홈페이지 메인 이미지", "https://kgu.ac.kr", FileEntity.builder().build())
+			Carousel.create("컴퓨터공학부 홈페이지 메인 이미지", "https://kgu.ac.kr", FAKE_FILE_ID)
 		);
 
 		fakeCarouselRepository.save(
-			Carousel.create("SW 중심대학 선정", "https://kgu.ac.kr", FileEntity.builder().build())
+			Carousel.create("SW 중심대학 선정", "https://kgu.ac.kr", FAKE_FILE_ID)
 		);
 	}
 

--- a/aics-domain/src/main/java/kgu/developers/domain/carousel/application/command/CarouselCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/carousel/application/command/CarouselCommandService.java
@@ -17,7 +17,7 @@ public class CarouselCommandService {
 
 	public Long createCarousel(Long fileId, String text, String link) {
 		FileEntity file = fileQueryService.getFileById(fileId);
-		Carousel carousel = Carousel.create(text, link, file);
+		Carousel carousel = Carousel.create(text, link, file.getId());
 		return carouselRepository.save(carousel).getId();
 	}
 
@@ -25,14 +25,9 @@ public class CarouselCommandService {
 	public void updateCarousel(Carousel carousel, String link, String text, Long fileId) {
 		carousel.updateText(text);
 		carousel.updateLink(link);
-
-		FileEntity file = null;
-		if (fileId != null) {
-			file = fileQueryService.getFileById(fileId);
-		}
-
-		carousel.updateFile(file);
+		carousel.updateFileId(fileId);
 	}
+
 	public void deleteCarouselById(Long id) {
 		carouselRepository.deleteById(id);
 	}

--- a/aics-domain/src/main/java/kgu/developers/domain/carousel/domain/Carousel.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/carousel/domain/Carousel.java
@@ -29,6 +29,7 @@ public class Carousel extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String link;
 
+	@Column(nullable = false)
 	private Long fileId;
 
 	public static Carousel create(String text, String link, Long fileId) {

--- a/aics-domain/src/main/java/kgu/developers/domain/carousel/domain/Carousel.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/carousel/domain/Carousel.java
@@ -1,6 +1,5 @@
 package kgu.developers.domain.carousel.domain;
 
-import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -8,10 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import kgu.developers.common.domain.BaseTimeEntity;
-import kgu.developers.domain.file.domain.FileEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,15 +29,13 @@ public class Carousel extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String link;
 
-	@OneToOne(cascade = REMOVE)
-	@JoinColumn(name = "file_id", nullable = false)
-	private FileEntity file;
+	private Long fileId;
 
-	public static Carousel create(String text, String link, FileEntity file) {
+	public static Carousel create(String text, String link, Long fileId) {
 		return Carousel.builder()
 			.text(text)
 			.link(link)
-			.file(file)
+			.fileId(fileId)
 			.build();
 	}
 
@@ -53,8 +47,8 @@ public class Carousel extends BaseTimeEntity {
 		this.link = link;
 	}
 
-	public void updateFile(FileEntity file) {
-		this.file = file;
+	public void updateFileId(Long fileId) {
+		this.fileId = fileId;
 	}
 }
 

--- a/aics-domain/src/main/java/kgu/developers/domain/carousel/infrastructure/CarouselRepositoryImpl.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/carousel/infrastructure/CarouselRepositoryImpl.java
@@ -26,7 +26,7 @@ public class CarouselRepositoryImpl implements CarouselRepository {
 
 	@Override
 	public List<Carousel> findAllByFileIsNotNullOrderByCreatedAtDesc() {
-		return jpaCarouselRepository.findAllByFileIsNotNullOrderByCreatedAtDesc();
+		return jpaCarouselRepository.findAllByFileIdIsNotNullOrderByCreatedAtDesc();
 	}
 
 	@Override

--- a/aics-domain/src/main/java/kgu/developers/domain/carousel/infrastructure/JpaCarouselRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/carousel/infrastructure/JpaCarouselRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import kgu.developers.domain.carousel.domain.Carousel;
 
 public interface JpaCarouselRepository extends JpaRepository<Carousel, Long> {
-	List<Carousel> findAllByFileIsNotNullOrderByCreatedAtDesc();
+	List<Carousel> findAllByFileIdIsNotNullOrderByCreatedAtDesc();
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/file/application/query/FileQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/application/query/FileQueryService.java
@@ -19,4 +19,9 @@ public class FileQueryService {
 	public List<FileEntity> findAllByIds(List<Long> ids) {
 		return fileRepository.findAllByIds(ids);
 	}
+
+	public String getFilePhysicalPath(Long id) {
+		return fileRepository.findPhysicalPathById(id)
+			.orElse(null);
+	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/file/application/response/FilePathResponse.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/application/response/FilePathResponse.java
@@ -1,6 +1,6 @@
 package kgu.developers.domain.file.application.response;
 
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import kgu.developers.domain.file.domain.FileEntity;
@@ -19,6 +19,14 @@ public record FilePathResponse(
 		String decryptedPath = AesUtil.decrypt(fileEntity.getPhysicalPath());
 		return FilePathResponse.builder()
 			.id(fileEntity.getId())
+			.physicalPath(decryptedPath)
+			.build();
+	}
+
+	public static FilePathResponse of(Long id, String physicalPath) {
+		String decryptedPath = AesUtil.decrypt(physicalPath);
+		return FilePathResponse.builder()
+			.id(id)
 			.physicalPath(decryptedPath)
 			.build();
 	}

--- a/aics-domain/src/main/java/kgu/developers/domain/file/domain/FileRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/domain/FileRepository.java
@@ -7,4 +7,5 @@ public interface FileRepository {
 	FileEntity save(FileEntity fileEntity);
 	Optional<FileEntity> findById(Long id);
 	List<FileEntity> findAllByIds(List<Long> ids);
+	Optional<String> findPhysicalPathById(Long id);
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/FileRepositoryImpl.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/FileRepositoryImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class FileRepositoryImpl implements FileRepository {
 	private final JpaFileRepository jpaFileRepository;
+	private final QueryFileRepository queryFileRepository;
 
 	@Override
 	public FileEntity save(FileEntity fileEntity) {
@@ -26,5 +27,10 @@ public class FileRepositoryImpl implements FileRepository {
 	@Override
 	public List<FileEntity> findAllByIds(List<Long> ids) {
 		return jpaFileRepository.findAllById(ids);
+	}
+
+	@Override
+	public Optional<String> findPhysicalPathById(Long id) {
+		return queryFileRepository.findPhysicalPathById(id);
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/QueryFileRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/QueryFileRepository.java
@@ -1,0 +1,27 @@
+package kgu.developers.domain.file.infrastructure;
+
+import static kgu.developers.domain.file.domain.QFileEntity.fileEntity;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryFileRepository {
+	private final JPAQueryFactory queryFactory;
+
+	public Optional<String> findPhysicalPathById(Long id) {
+		String path = queryFactory
+			.select(fileEntity.physicalPath)
+			.from(fileEntity)
+			.where(fileEntity.id.eq(id))
+			.fetchOne();
+
+		return Optional.ofNullable(path);
+	}
+}

--- a/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/QueryFileRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/infrastructure/QueryFileRepository.java
@@ -16,12 +16,12 @@ public class QueryFileRepository {
 	private final JPAQueryFactory queryFactory;
 
 	public Optional<String> findPhysicalPathById(Long id) {
-		String path = queryFactory
-			.select(fileEntity.physicalPath)
-			.from(fileEntity)
-			.where(fileEntity.id.eq(id))
-			.fetchOne();
-
-		return Optional.ofNullable(path);
+		return Optional.ofNullable(id)
+			.map(i -> queryFactory
+				.select(fileEntity.physicalPath)
+				.from(fileEntity)
+				.where(fileEntity.id.eq(i))
+				.fetchOne()
+			);
 	}
 }

--- a/aics-domain/src/testFixtures/java/carousel/application/CarouselCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/carousel/application/CarouselCommandServiceTest.java
@@ -73,6 +73,6 @@ public class CarouselCommandServiceTest {
 		// then
 		assertEquals(text, carousel.getText());
 		assertEquals(link, carousel.getLink());
-		assertNull(carousel.getFile());
+		assertNull(carousel.getFileId());
 	}
 }

--- a/aics-domain/src/testFixtures/java/carousel/application/CarouselQueryServiceTest.java
+++ b/aics-domain/src/testFixtures/java/carousel/application/CarouselQueryServiceTest.java
@@ -17,6 +17,8 @@ public class CarouselQueryServiceTest {
 	private CarouselQueryService carouselQueryService;
 	private static Carousel carousel;
 
+	private static final Long FAKE_FILE_ID = 1L;
+
 	@BeforeEach
 	public void init() {
 		FakeCarouselRepository fakeCarouselRepository = new FakeCarouselRepository();
@@ -26,11 +28,11 @@ public class CarouselQueryServiceTest {
 
 	private static void saveTestCarousel(FakeCarouselRepository fakeCarouselRepository) {
 		carousel = fakeCarouselRepository.save(
-			Carousel.create("컴퓨터공학부 홈페이지 메인 이미지", "https://kgu.ac.kr", FileEntity.builder().build())
+			Carousel.create("컴퓨터공학부 홈페이지 메인 이미지", "https://kgu.ac.kr", FAKE_FILE_ID)
 		);
 
 		fakeCarouselRepository.save(
-			Carousel.create("SW 중심대학 선정", "https://kgu.ac.kr", FileEntity.builder().build())
+			Carousel.create("SW 중심대학 선정", "https://kgu.ac.kr", FAKE_FILE_ID)
 		);
 	}
 

--- a/aics-domain/src/testFixtures/java/carousel/domain/CarouselDomainTest.java
+++ b/aics-domain/src/testFixtures/java/carousel/domain/CarouselDomainTest.java
@@ -12,14 +12,14 @@ import kgu.developers.domain.file.domain.FileEntity;
 public class CarouselDomainTest {
 	private static final String TARGET_CAROUSEL_TEXT = "컴퓨터공학부 대표 이미지";
 	private static final String TARGET_CAROUSEL_LINK = "https://kgu.ac.kr";
+	private static final Long FAKE_FILE_ID = 1L;
 
 	@Test
 	@DisplayName("create 정적 팩토리 메서드는 Carousel 객체를 생성할 수 있다")
 	public void createCarousel_success() {
 		//given
 		//when
-		Carousel createdCarousel = Carousel.create(TARGET_CAROUSEL_TEXT, TARGET_CAROUSEL_LINK,
-			FileEntity.builder().build());
+		Carousel createdCarousel = Carousel.create(TARGET_CAROUSEL_TEXT, TARGET_CAROUSEL_LINK, FAKE_FILE_ID);
 
 		//then
 		assertNotNull(createdCarousel);
@@ -63,9 +63,9 @@ public class CarouselDomainTest {
 		FileEntity file = FileEntity.builder().build();
 
 		// when
-		carousel.updateFile(file);
+		carousel.updateFileId(file.getId());
 
 		// then
-		assertEquals(file, carousel.getFile());
+		assertEquals(file.getId(), carousel.getFileId());
 	}
 }

--- a/aics-domain/src/testFixtures/java/mock/repository/FakeCarouselRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/repository/FakeCarouselRepository.java
@@ -21,7 +21,7 @@ public class FakeCarouselRepository implements CarouselRepository {
 			.id(sequence.getAndIncrement())
 			.text(carousel.getText())
 			.link(carousel.getLink())
-			.file(carousel.getFile())
+			.fileId(carousel.getFileId())
 			.build();
 
 		TestEntityUtils.setCreatedAt(savedCarousel, LocalDateTime.now());
@@ -38,7 +38,7 @@ public class FakeCarouselRepository implements CarouselRepository {
 	@Override
 	public List<Carousel> findAllByFileIsNotNullOrderByCreatedAtDesc() {
 		return data.stream()
-			.filter(carousel -> carousel.getFile() != null)
+			.filter(carousel -> carousel.getFileId() != null)
 			.sorted((c1, c2) -> c2.getCreatedAt().compareTo(c1.getCreatedAt()))
 			.toList();
 	}

--- a/aics-domain/src/testFixtures/java/mock/repository/FakeFileRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/repository/FakeFileRepository.java
@@ -37,5 +37,13 @@ public class FakeFileRepository implements FileRepository {
 				.filter(file -> ids.contains(file.getId()))
 				.toList();
 	}
+
+	@Override
+	public Optional<String> findPhysicalPathById(Long id) {
+		return data.stream()
+			.filter(fileEntity -> fileEntity.getId().equals(id))
+			.map(FileEntity::getPhysicalPath)
+			.findFirst();
+	}
 }
 

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "0.8.11"
+    toolVersion = "0.8.12"
     reportsDirectory = layout.buildDirectory.dir('jacoco')
 }
 


### PR DESCRIPTION
## Summary

>- #257 

`Carousel` 엔티티와 `FIleEntity` 간 ID 참조 방식으로 매핑하도록 변경하였습니다. 
또한 `FIlePathResponse`를 외부에서 생성할 때 `FileEntity`에 의존하지 않도록 `of` 정적팩토리메서드를 추가하였습니다.

## Tasks

- `Carousel` 엔티티와 `FileEntity` 간 ID 참조 방식으로 매핑
- 리팩토링에 따른 테스트 코드 의존성 수정

## To Reviewer

Spring Data JPA를 사용할 경우, 단일 컬럼만 조회하려면 인터페이스 기반 Projection을 사용해야 하는 불편함이 있습니다.
이에 따라, 인수인계와 코드 컨벤션 측면을 고려하여 JPA 대신 QueryDSL을 활용하였습니다.
QueryDSL을 사용하면 엔티티 전체를 조회하는 것보다 성능이 뛰어나며, JPA 1차 캐시 등으로 인한 불필요한 메모리 사용도 줄일 수 있습니다.

## Screenshot

_(없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._
