### PR TITLE
refactor/#251 User, Post, Comment, FileEntity간 관계 매핑을 ID 참조로 변경

### DIFF
--- a/aics-admin/src/testFixtures/java/post/application/PostAdminFacadeTest.java
+++ b/aics-admin/src/testFixtures/java/post/application/PostAdminFacadeTest.java
@@ -44,7 +44,7 @@ public class PostAdminFacadeTest {
 		FileQueryService fileQueryService = new FileQueryService(fakeFileRepository);
 		this.postAdminFacade = new PostAdminFacade(
 			new PostCommandService(userQueryService, fakePostRepository, fileQueryService),
-			new PostQueryService(fakePostRepository, fakeFileRepository),
+			new PostQueryService(fakePostRepository, fakeFileRepository, fakeUserRepository),
 			new PostSchedulingService(fakePostRepository)
 		);
 
@@ -65,7 +65,7 @@ public class PostAdminFacadeTest {
 
 		fakePostRepository.save(
 			Post.create(
-				"post title", "post content", NOTIFICATION, author, null, false
+				"post title", "post content", NOTIFICATION, author.getId(), null, false
 			)
 		);
 	}

--- a/aics-admin/src/testFixtures/java/post/application/PostAdminFacadeTest.java
+++ b/aics-admin/src/testFixtures/java/post/application/PostAdminFacadeTest.java
@@ -44,7 +44,7 @@ public class PostAdminFacadeTest {
 		FileQueryService fileQueryService = new FileQueryService(fakeFileRepository);
 		this.postAdminFacade = new PostAdminFacade(
 			new PostCommandService(userQueryService, fakePostRepository, fileQueryService),
-			new PostQueryService(fakePostRepository),
+			new PostQueryService(fakePostRepository, fakeFileRepository),
 			new PostSchedulingService(fakePostRepository)
 		);
 

--- a/aics-api/src/main/java/kgu/developers/api/comment/application/CommentFacade.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/application/CommentFacade.java
@@ -1,7 +1,10 @@
 package kgu.developers.api.comment.application;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import kgu.developers.domain.user.application.query.UserQueryService;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +25,7 @@ public class CommentFacade {
 	private final CommentCommandService commentCommandService;
 	private final CommentQueryService commentQueryService;
 	private final CommentSchedulingService commentSchedulingService;
+	private final UserQueryService userQueryService;
 
 	public CommentPersistResponse createComment(CommentRequest request) {
 		Long id = commentCommandService.createComment(request.content(), request.postId());
@@ -30,7 +34,11 @@ public class CommentFacade {
 
 	public CommentListResponse getComments(Long postId) {
 		List<Comment> comments = commentQueryService.getComments(postId);
-		return CommentListResponse.from(comments);
+
+		List<String> authorIds = comments.stream().map(Comment::getAuthorId).collect(Collectors.toList());
+
+		Map<String, String> nameMap = userQueryService.getUserNameMapByIds(authorIds);
+		return CommentListResponse.from(comments,nameMap);
 	}
 
 	public void updateComment(Long commentId, CommentUpdateRequest request) {

--- a/aics-api/src/main/java/kgu/developers/api/comment/presentation/response/CommentListResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/presentation/response/CommentListResponse.java
@@ -7,6 +7,7 @@ import kgu.developers.domain.comment.domain.Comment;
 import lombok.Builder;
 
 import java.util.List;
+import java.util.Map;
 
 @Builder
 public record CommentListResponse(
@@ -19,10 +20,10 @@ public record CommentListResponse(
 		requiredMode = REQUIRED)
 	List<CommentResponse> contents
 ) {
-	public static CommentListResponse from(List<Comment> comments) {
+	public static CommentListResponse from(List<Comment> comments, Map<String,String> nameMap) {
 		return CommentListResponse.builder()
 			.contents(comments.stream()
-				.map(CommentResponse::from)
+				.map(comment -> CommentResponse.from(comment,nameMap.get(comment.getAuthorId())))
 				.toList())
 			.build();
 	}

--- a/aics-api/src/main/java/kgu/developers/api/comment/presentation/response/CommentResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/comment/presentation/response/CommentResponse.java
@@ -24,11 +24,11 @@ public record CommentResponse(
 	@Schema(description = "내용", example = "예시 코멘트입니다, 좋은 소식이네요!", requiredMode = REQUIRED)
 	String content
 ) {
-	public static CommentResponse from(Comment comment) {
+	public static CommentResponse from(Comment comment, String authorName) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 		return CommentResponse.builder()
 			.commentId(comment.getId())
-			.author(comment.getAuthor().getName())
+			.author(authorName)
 			.createdAt(comment.getCreatedAt().format(formatter))
 			.content(comment.getContent())
 			.build();

--- a/aics-api/src/main/java/kgu/developers/api/post/application/PostFacade.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/application/PostFacade.java
@@ -1,7 +1,11 @@
 package kgu.developers.api.post.application;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import kgu.developers.domain.user.application.query.UserQueryService;
+import kgu.developers.domain.user.domain.User;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,12 +24,26 @@ import lombok.RequiredArgsConstructor;
 public class PostFacade {
 	private final PostCommandService postCommandService;
 	private final PostQueryService postQueryService;
+	private final UserQueryService userQueryService;
 
 	public PostSummaryPageResponse getPostsByKeywordAndCategory(PageRequest request, List<String> keywords,
 		Category category) {
 		PaginatedListResponse<Post> paginatedListResponse = postQueryService.getPostsByKeywordAndCategory(request,
 			keywords, category);
-		return PostSummaryPageResponse.of(paginatedListResponse.contents(), paginatedListResponse.pageable());
+
+		List<String> authorIds = paginatedListResponse.contents().stream()
+			.map(Post::getAuthorId)
+			.distinct()
+			.toList();
+
+		Map<String, String> authorNameMap = userQueryService.getAllUsersByIds(authorIds).stream()
+			.collect(Collectors.toMap(
+				User::getId,
+				User::getName
+			));
+
+		return PostSummaryPageResponse.of(paginatedListResponse.contents(),
+			paginatedListResponse.pageable(), authorNameMap);
 	}
 
 	@Transactional

--- a/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryPageResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryPageResponse.java
@@ -5,9 +5,11 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import io.swagger.v3.oas.annotations.media.Schema;
 import kgu.developers.common.response.PageableResponse;
 import kgu.developers.domain.post.domain.Post;
+import kgu.developers.domain.user.domain.User;
 import lombok.Builder;
 
 import java.util.List;
+import java.util.Map;
 
 @Builder
 public record PostSummaryPageResponse<T>(
@@ -28,10 +30,10 @@ public record PostSummaryPageResponse<T>(
 	@Schema(description = "페이징 정보", requiredMode = REQUIRED)
 	PageableResponse<T> pageable
 ) {
-	public static <T> PostSummaryPageResponse<T> of(List<Post> posts, PageableResponse<T> pageable) {
+	public static <T> PostSummaryPageResponse<T> of(List<Post> posts, PageableResponse<T> pageable, Map<String, String>authorNameMap) {
 		return PostSummaryPageResponse.<T>builder()
 			.contents(posts.stream()
-				.map(PostSummaryResponse::from)
+				.map(post -> PostSummaryResponse.from(post, authorNameMap.get(post.getAuthorId())))
 				.toList())
 			.pageable(pageable)
 			.build();

--- a/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryPageResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryPageResponse.java
@@ -5,7 +5,6 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import io.swagger.v3.oas.annotations.media.Schema;
 import kgu.developers.common.response.PageableResponse;
 import kgu.developers.domain.post.domain.Post;
-import kgu.developers.domain.user.domain.User;
 import lombok.Builder;
 
 import java.util.List;

--- a/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryResponse.java
@@ -2,7 +2,6 @@ package kgu.developers.api.post.presentation.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import kgu.developers.domain.post.domain.Post;
-import kgu.developers.domain.user.domain.User;
 import lombok.Builder;
 import org.springframework.format.annotation.DateTimeFormat;
 

--- a/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/post/presentation/response/PostSummaryResponse.java
@@ -2,6 +2,7 @@ package kgu.developers.api.post.presentation.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import kgu.developers.domain.post.domain.Post;
+import kgu.developers.domain.user.domain.User;
 import lombok.Builder;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -39,7 +40,7 @@ public record PostSummaryResponse(
 	@DateTimeFormat(pattern = "yyyy-MM-dd")
 	String createdAt
 ) {
-	public static PostSummaryResponse from(Post post) {
+	public static PostSummaryResponse from(Post post, String authorName) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
 		String content = post.getContent();
@@ -49,7 +50,7 @@ public record PostSummaryResponse(
 			.postId(post.getId())
 			.category(post.getCategory().getDescription())
 			.title(post.getTitle())
-			.author(post.getAuthor().getName())
+			.author(authorName)
 			.description(description)
 			.views(post.getViews())
 			.hasAttachment(false) // TODO : 첨부파일 여부 확인

--- a/aics-api/src/testFixtures/java/comment/application/CommentFacadeTest.java
+++ b/aics-api/src/testFixtures/java/comment/application/CommentFacadeTest.java
@@ -44,14 +44,17 @@ public class CommentFacadeTest {
 		FakePostRepository fakePostRepository = new FakePostRepository();
 
 		UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
+		PostQueryService postQueryService = new PostQueryService(fakePostRepository, fakeFileRepository, fakeUserRepository);
+
 		commentFacade = new CommentFacade(
 			new CommentCommandService(
-				new PostQueryService(fakePostRepository, fakeFileRepository, fakeUserRepository),
+				postQueryService,
 				userQueryService,
 				fakeCommentRepository
 			),
 			new CommentQueryService(fakeCommentRepository),
-			new CommentSchedulingService(fakeCommentRepository)
+			new CommentSchedulingService(fakeCommentRepository),
+			userQueryService
 		);
 
 		User author = fakeUserRepository.save(User.builder()
@@ -68,11 +71,11 @@ public class CommentFacadeTest {
 		));
 
 		fakeCommentRepository.save(Comment.create(
-			"test1", author, post
+			"test1", author.getId(), post.getId()
 		));
 
 		Comment delete = fakeCommentRepository.save(Comment.create(
-			"test2", author, post
+			"test2", author.getId(), post.getId()
 		));
 		delete.delete();
 

--- a/aics-api/src/testFixtures/java/comment/application/CommentFacadeTest.java
+++ b/aics-api/src/testFixtures/java/comment/application/CommentFacadeTest.java
@@ -46,7 +46,7 @@ public class CommentFacadeTest {
 		UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
 		commentFacade = new CommentFacade(
 			new CommentCommandService(
-				new PostQueryService(fakePostRepository, fakeFileRepository),
+				new PostQueryService(fakePostRepository, fakeFileRepository, fakeUserRepository),
 				userQueryService,
 				fakeCommentRepository
 			),
@@ -64,7 +64,7 @@ public class CommentFacadeTest {
 			.build());
 
 		Post post = fakePostRepository.save(Post.create(
-			"테스트용 제목1", "테스트용 내용1", NEWS, author, null, false
+			"테스트용 제목1", "테스트용 내용1", NEWS, author.getId(), null, false
 		));
 
 		fakeCommentRepository.save(Comment.create(

--- a/aics-api/src/testFixtures/java/comment/application/CommentFacadeTest.java
+++ b/aics-api/src/testFixtures/java/comment/application/CommentFacadeTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
+import mock.repository.FakeFileRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,12 +40,13 @@ public class CommentFacadeTest {
 	public void init() {
 		FakeCommentRepository fakeCommentRepository = new FakeCommentRepository();
 		FakeUserRepository fakeUserRepository = new FakeUserRepository();
+		FakeFileRepository fakeFileRepository = new FakeFileRepository();
 		FakePostRepository fakePostRepository = new FakePostRepository();
 
 		UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
 		commentFacade = new CommentFacade(
 			new CommentCommandService(
-				new PostQueryService(fakePostRepository),
+				new PostQueryService(fakePostRepository, fakeFileRepository),
 				userQueryService,
 				fakeCommentRepository
 			),

--- a/aics-api/src/testFixtures/java/post/application/PostFacadeTest.java
+++ b/aics-api/src/testFixtures/java/post/application/PostFacadeTest.java
@@ -48,7 +48,7 @@ public class PostFacadeTest {
 
 		postFacade = new PostFacade(
 			new PostCommandService(userQueryService, fakePostRepository, fileQueryService),
-			new PostQueryService(fakePostRepository)
+			new PostQueryService(fakePostRepository, fakeFileRepository)
 		);
 
 		User author = fakeUserRepository.save(User.builder()

--- a/aics-api/src/testFixtures/java/post/application/PostFacadeTest.java
+++ b/aics-api/src/testFixtures/java/post/application/PostFacadeTest.java
@@ -48,7 +48,8 @@ public class PostFacadeTest {
 
 		postFacade = new PostFacade(
 			new PostCommandService(userQueryService, fakePostRepository, fileQueryService),
-			new PostQueryService(fakePostRepository, fakeFileRepository)
+			new PostQueryService(fakePostRepository, fakeFileRepository, fakeUserRepository),
+			new UserQueryService(fakeUserRepository)
 		);
 
 		User author = fakeUserRepository.save(User.builder()
@@ -67,16 +68,16 @@ public class PostFacadeTest {
 		);
 
 		fakePostRepository.save(Post.create(
-			"first title", "first content", NEWS, author, null, false
+			"first title", "first content", NEWS, author.getId(), null, false
 		));
 
 		Post delete = fakePostRepository.save(Post.create(
-			"second title", "second content", NEWS, author, null, false
+			"second title", "second content", NEWS, author.getId(), null, false
 		));
 		delete.delete();
 
 		fakePostRepository.save(Post.create(
-			"third title", "third content", NEWS, author, null, false
+			"third title", "third content", NEWS, author.getId(), null, false
 		));
 	}
 

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/application/command/CommentCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/application/command/CommentCommandService.java
@@ -20,7 +20,7 @@ public class CommentCommandService {
 	public Long createComment(String content, Long postId) {
 		Post post = postQueryService.getById(postId);
 		User user = userQueryService.me();
-		Comment comment = Comment.create(content, user, post);
+		Comment comment = Comment.create(content, user.getId(), post.getId());
 		return commentRepository.save(comment).getId();
 	}
 

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/domain/Comment.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/domain/Comment.java
@@ -1,18 +1,12 @@
 package kgu.developers.domain.comment.domain;
 
-import static jakarta.persistence.FetchType.EAGER;
-import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import kgu.developers.common.domain.BaseTimeEntity;
-import kgu.developers.domain.post.domain.Post;
-import kgu.developers.domain.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,19 +25,17 @@ public class Comment extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String content;
 
-	@ManyToOne(fetch = EAGER)
-	@JoinColumn(name = "post_id", nullable = false)
-	private Post post;
+	@Column(name = "post_id",nullable = false)
+	private Long postId;
 
-	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "author_id", nullable = false)
-	private User author;
+	@Column(name = "author_id", nullable = false)
+	private String authorId;
 
-	public static Comment create(String content, User author, Post post) {
+	public static Comment create(String content, String authorId, Long postId) {
 		return Comment.builder()
 			.content(content)
-			.author(author)
-			.post(post)
+			.authorId(authorId)
+			.postId(postId)
 			.build();
 	}
 

--- a/aics-domain/src/main/java/kgu/developers/domain/comment/domain/Comment.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/comment/domain/Comment.java
@@ -25,10 +25,10 @@ public class Comment extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String content;
 
-	@Column(name = "post_id",nullable = false)
+	@Column(nullable = false)
 	private Long postId;
 
-	@Column(name = "author_id", nullable = false)
+	@Column(nullable = false)
 	private String authorId;
 
 	public static Comment create(String content, String authorId, Long postId) {

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
@@ -3,7 +3,6 @@ package kgu.developers.domain.post.application.command;
 import org.springframework.stereotype.Service;
 
 import kgu.developers.domain.file.application.query.FileQueryService;
-import kgu.developers.domain.file.domain.FileEntity;
 import kgu.developers.domain.post.domain.Category;
 import kgu.developers.domain.post.domain.Post;
 import kgu.developers.domain.post.domain.PostRepository;

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
@@ -29,7 +29,7 @@ public class PostCommandService {
 		post.updateContent(content);
 		post.updateCategory(category);
 		post.updatePinned(isPinned);
-		post.updateFile(fileId);
+		post.updateFileId(fileId);
 	}
 
 	public void togglePostPinStatus(Post post) {

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
@@ -21,11 +21,7 @@ public class PostCommandService {
 	public Long createPost(String title, String content, Category category, Long fileId, boolean isPinned) {
 		User author = userQueryService.me();
 
-		FileEntity file = null;
-		if (fileId != null)
-			file = fileQueryService.getFileById(fileId);
-
-		Post post = Post.create(title, content, category, author, file, isPinned);
+		Post post = Post.create(title, content, category, author, fileId, isPinned);
 		return postRepository.save(post).getId();
 	}
 
@@ -34,12 +30,7 @@ public class PostCommandService {
 		post.updateContent(content);
 		post.updateCategory(category);
 		post.updatePinned(isPinned);
-
-		FileEntity file = null;
-		if (fileId != null)
-			file = fileQueryService.getFileById(fileId);
-
-		post.updateFile(file);
+		post.updateFile(fileId);
 	}
 
 	public void togglePostPinStatus(Post post) {

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/command/PostCommandService.java
@@ -21,7 +21,7 @@ public class PostCommandService {
 	public Long createPost(String title, String content, Category category, Long fileId, boolean isPinned) {
 		User author = userQueryService.me();
 
-		Post post = Post.create(title, content, category, author, fileId, isPinned);
+		Post post = Post.create(title, content, category, author.getId(), fileId, isPinned);
 		return postRepository.save(post).getId();
 	}
 

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/query/PostQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/query/PostQueryService.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import kgu.developers.domain.file.application.response.FilePathResponse;
 import kgu.developers.domain.file.domain.FileEntity;
 import kgu.developers.domain.file.domain.FileRepository;
+import kgu.developers.domain.user.domain.User;
+import kgu.developers.domain.user.domain.UserRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
@@ -24,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class PostQueryService {
 	private final PostRepository postRepository;
 	private final FileRepository fileRepository;
+	private final UserRepository userRepository;
 
 	public PaginatedListResponse<Post> getPostsByKeywordAndCategory(PageRequest request, List<String> keywords,
 		Category category) {
@@ -39,9 +42,10 @@ public class PostQueryService {
 		Post nextPost = postRepository.findByNextPost(timestamp, category).orElse(null);
 
 		FileEntity file = fileRepository.findById(post.getFileId()).orElse(null);
+		User author = userRepository.findById(post.getAuthorId()).orElse(null);
 		PostTitleResponse prevPostResponse = PostTitleResponse.from(prevPost);
 		PostTitleResponse nextPostResponse = PostTitleResponse.from(nextPost);
-		return PostDetailResponse.from(post, file, prevPostResponse, nextPostResponse);
+		return PostDetailResponse.from(post, author, file, prevPostResponse, nextPostResponse);
 	}
 
 	public Post getById(Long postId) {

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/query/PostQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/query/PostQueryService.java
@@ -33,11 +33,13 @@ public class PostQueryService {
 	}
 
 	public PostDetailResponse getPostByIdWithPrevAndNext(Post post) {
+
+		Long postId = post.getId();
 		LocalDateTime timestamp = post.getCreatedAt();
 		Category category = post.getCategory();
 
-		Post prevPost = postRepository.findByPrevPost(timestamp, category).orElse(null);
-		Post nextPost = postRepository.findByNextPost(timestamp, category).orElse(null);
+		Post prevPost = postRepository.findByPrevPost(postId, timestamp, category).orElse(null);
+		Post nextPost = postRepository.findByNextPost(postId, timestamp, category).orElse(null);
 
 		FileEntity file = fileRepository.findById(post.getFileId()).orElse(null);
 		User author = userRepository.findById(post.getAuthorId()).orElse(null);

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/query/PostQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/query/PostQueryService.java
@@ -28,7 +28,7 @@ public class PostQueryService {
 
 	public PaginatedListResponse<Post> getPostsByKeywordAndCategory(PageRequest request, List<String> keywords,
 		Category category) {
-		return postRepository.findAllByTitleContainingAndCategoryOrderByCreatedAtDesc(
+		return postRepository.findAllByTitleContainingAndCategoryOrderByCreatedAtDescIdDesc(
 			keywords, category, request);
 	}
 

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/query/PostQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/query/PostQueryService.java
@@ -2,9 +2,7 @@ package kgu.developers.domain.post.application.query;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
-import kgu.developers.domain.file.application.response.FilePathResponse;
 import kgu.developers.domain.file.domain.FileEntity;
 import kgu.developers.domain.file.domain.FileRepository;
 import kgu.developers.domain.user.domain.User;

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/query/PostQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/query/PostQueryService.java
@@ -2,7 +2,11 @@ package kgu.developers.domain.post.application.query;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
+import kgu.developers.domain.file.application.response.FilePathResponse;
+import kgu.developers.domain.file.domain.FileEntity;
+import kgu.developers.domain.file.domain.FileRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostQueryService {
 	private final PostRepository postRepository;
+	private final FileRepository fileRepository;
 
 	public PaginatedListResponse<Post> getPostsByKeywordAndCategory(PageRequest request, List<String> keywords,
 		Category category) {
@@ -33,9 +38,10 @@ public class PostQueryService {
 		Post prevPost = postRepository.findByPrevPost(timestamp, category).orElse(null);
 		Post nextPost = postRepository.findByNextPost(timestamp, category).orElse(null);
 
+		FileEntity file = fileRepository.findById(post.getFileId()).orElse(null);
 		PostTitleResponse prevPostResponse = PostTitleResponse.from(prevPost);
 		PostTitleResponse nextPostResponse = PostTitleResponse.from(nextPost);
-		return PostDetailResponse.from(post, prevPostResponse, nextPostResponse);
+		return PostDetailResponse.from(post, file, prevPostResponse, nextPostResponse);
 	}
 
 	public Post getById(Long postId) {

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/response/PostDetailResponse.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/response/PostDetailResponse.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.format.DateTimeFormatter;
 
+import kgu.developers.domain.file.domain.FileEntity;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -65,7 +66,7 @@ public record PostDetailResponse(
 	PostTitleResponse nextPost
 
 ) {
-	public static PostDetailResponse from(Post post, PostTitleResponse prevPost, PostTitleResponse nextPost) {
+	public static PostDetailResponse from(Post post, FileEntity file, PostTitleResponse prevPost, PostTitleResponse nextPost) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 		return PostDetailResponse.builder()
 			.postId(post.getId())
@@ -75,8 +76,8 @@ public record PostDetailResponse(
 			.author(post.getAuthor().getName())
 			.views(post.getViews())
 			.isPinned(post.isPinned())
-			.file(post.getFile() != null ?
-				FilePathResponse.from(post.getFile()) : null)
+			.file(file != null ?
+				FilePathResponse.from(file) : null)
 			.createdAt(post.getCreatedAt().format(formatter))
 			.prevPost(prevPost)
 			.nextPost(nextPost)

--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/response/PostDetailResponse.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/response/PostDetailResponse.java
@@ -6,6 +6,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import java.time.format.DateTimeFormatter;
 
 import kgu.developers.domain.file.domain.FileEntity;
+import kgu.developers.domain.user.domain.User;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -66,14 +67,14 @@ public record PostDetailResponse(
 	PostTitleResponse nextPost
 
 ) {
-	public static PostDetailResponse from(Post post, FileEntity file, PostTitleResponse prevPost, PostTitleResponse nextPost) {
+	public static PostDetailResponse from(Post post, User author, FileEntity file, PostTitleResponse prevPost, PostTitleResponse nextPost) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 		return PostDetailResponse.builder()
 			.postId(post.getId())
 			.category(post.getCategory().getDescription())
 			.title(post.getTitle())
 			.content(post.getContent())
-			.author(post.getAuthor().getName())
+			.author(author.getName())
 			.views(post.getViews())
 			.isPinned(post.isPinned())
 			.file(file != null ?

--- a/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
@@ -57,15 +57,13 @@ public class Post extends BaseTimeEntity {
 	@Column(nullable = false)
 	private boolean isPinned;
 
-	@OneToOne
-	@JoinColumn(name = "file_id")
-	private FileEntity file;
+	private Long fileId;
 
 	@Builder.Default
 	@OneToMany(mappedBy = "post", fetch = LAZY, cascade = ALL, orphanRemoval = true)
 	private List<Comment> comments = new ArrayList<>();
 
-	public static Post create(String title, String content, Category category, User author, FileEntity file, boolean isPinned) {
+	public static Post create(String title, String content, Category category, User author, Long fileId, boolean isPinned) {
 		return Post.builder()
 			.title(title)
 			.content(content)
@@ -73,7 +71,7 @@ public class Post extends BaseTimeEntity {
 			.isPinned(isPinned)
 			.category(category)
 			.author(author)
-			.file(file)
+			.fileId(fileId)
 			.build();
 	}
 
@@ -97,8 +95,8 @@ public class Post extends BaseTimeEntity {
 		this.views++;
 	}
 
-	public void updateFile(FileEntity file) {
-		this.file = file;
+	public void updateFile(Long fileId) {
+		this.fileId = fileId;
 	}
 
 	public void togglePinned() {

--- a/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
@@ -50,9 +50,8 @@ public class Post extends BaseTimeEntity {
 	@Enumerated(STRING)
 	private Category category;
 
-	@ManyToOne(fetch = EAGER)
-	@JoinColumn(name = "author_id")
-	private User author;
+	@Column(nullable = false)
+	private String authorId;
 
 	@Column(nullable = false)
 	private boolean isPinned;
@@ -63,14 +62,14 @@ public class Post extends BaseTimeEntity {
 	@OneToMany(mappedBy = "post", fetch = LAZY, cascade = ALL, orphanRemoval = true)
 	private List<Comment> comments = new ArrayList<>();
 
-	public static Post create(String title, String content, Category category, User author, Long fileId, boolean isPinned) {
+	public static Post create(String title, String content, Category category, String authorId, Long fileId, boolean isPinned) {
 		return Post.builder()
 			.title(title)
 			.content(content)
 			.views(0)
 			.isPinned(isPinned)
 			.category(category)
-			.author(author)
+			.authorId(authorId)
 			.fileId(fileId)
 			.build();
 	}

--- a/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
@@ -77,7 +77,7 @@ public class Post extends BaseTimeEntity {
 		this.views++;
 	}
 
-	public void updateFile(Long fileId) {
+	public void updateFileId(Long fileId) {
 		this.fileId = fileId;
 	}
 

--- a/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
@@ -1,28 +1,15 @@
 package kgu.developers.domain.post.domain;
 
-import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.EnumType.STRING;
-import static jakarta.persistence.FetchType.EAGER;
-import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import kgu.developers.common.domain.BaseTimeEntity;
-import kgu.developers.domain.comment.domain.Comment;
-import kgu.developers.domain.file.domain.FileEntity;
-import kgu.developers.domain.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -57,10 +44,6 @@ public class Post extends BaseTimeEntity {
 	private boolean isPinned;
 
 	private Long fileId;
-
-	@Builder.Default
-	@OneToMany(mappedBy = "post", fetch = LAZY, cascade = ALL, orphanRemoval = true)
-	private List<Comment> comments = new ArrayList<>();
 
 	public static Post create(String title, String content, Category category, String authorId, Long fileId, boolean isPinned) {
 		return Post.builder()

--- a/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/domain/Post.java
@@ -37,7 +37,7 @@ public class Post extends BaseTimeEntity {
 	@Enumerated(STRING)
 	private Category category;
 
-	@Column(nullable = false)
+	@Column(nullable = false, length = 10)
 	private String authorId;
 
 	@Column(nullable = false)

--- a/aics-domain/src/main/java/kgu/developers/domain/post/domain/PostRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/domain/PostRepository.java
@@ -18,7 +18,7 @@ public interface PostRepository {
 
 	void deleteAllByDeletedAtBefore(int retentionDays);
 
-	Optional<Post> findByPrevPost(LocalDateTime createdAt, Category category);
+	Optional<Post> findByPrevPost(Long postId, LocalDateTime createdAt, Category category);
 
-	Optional<Post> findByNextPost(LocalDateTime createdAt, Category category);
+	Optional<Post> findByNextPost(Long postId, LocalDateTime createdAt, Category category);
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/post/domain/PostRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/domain/PostRepository.java
@@ -11,7 +11,7 @@ import kgu.developers.common.response.PaginatedListResponse;
 public interface PostRepository {
 	Post save(Post post);
 
-	PaginatedListResponse<Post> findAllByTitleContainingAndCategoryOrderByCreatedAtDesc(List<String> keywords,
+	PaginatedListResponse<Post> findAllByTitleContainingAndCategoryOrderByCreatedAtDescIdDesc(List<String> keywords,
 		Category category, Pageable pageable);
 
 	Optional<Post> findByIdAndDeletedAtIsNull(Long postId);

--- a/aics-domain/src/main/java/kgu/developers/domain/post/infrastructure/PostRepositoryImpl.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/infrastructure/PostRepositoryImpl.java
@@ -30,9 +30,9 @@ public class PostRepositoryImpl implements PostRepository {
 	}
 
 	@Override
-	public PaginatedListResponse findAllByTitleContainingAndCategoryOrderByCreatedAtDesc(List<String> keywords,
+	public PaginatedListResponse findAllByTitleContainingAndCategoryOrderByCreatedAtDescIdDesc(List<String> keywords,
 		Category category, Pageable pageable) {
-		return queryPostRepository.findAllByTitleContainingAndCategoryOrderByCreatedAtDesc(keywords, category, pageable);
+		return queryPostRepository.findAllByTitleContainingAndCategoryOrderByCreatedAtDescIdDesc(keywords, category, pageable);
 	}
 
 	@Override

--- a/aics-domain/src/main/java/kgu/developers/domain/post/infrastructure/PostRepositoryImpl.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/infrastructure/PostRepositoryImpl.java
@@ -41,15 +41,13 @@ public class PostRepositoryImpl implements PostRepository {
 	}
 
 	@Override
-	public Optional<Post> findByPrevPost(LocalDateTime createdAt, Category category) {
-		return jpaPostRepository.findFirstByCreatedAtLessThanAndDeletedAtIsNullAndCategoryOrderByCreatedAtDesc(
-			createdAt, category);
+	public Optional<Post> findByPrevPost(Long postId, LocalDateTime createdAt, Category category) {
+		return queryPostRepository.findPreviousPost(postId, createdAt, category);
 	}
 
 	@Override
-	public Optional<Post> findByNextPost(LocalDateTime createdAt, Category category) {
-		return jpaPostRepository.findFirstByCreatedAtGreaterThanAndDeletedAtIsNullAndCategoryOrderByCreatedAtAsc(
-			createdAt, category);
+	public Optional<Post> findByNextPost(Long postId, LocalDateTime createdAt, Category category) {
+		return queryPostRepository.findNextPost(postId, createdAt, category);
 	}
 
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/post/infrastructure/QueryPostRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/infrastructure/QueryPostRepository.java
@@ -5,8 +5,10 @@ import static kgu.developers.domain.post.domain.QPost.post;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import com.querydsl.jpa.JPAExpressions;
+import kgu.developers.domain.post.domain.QPost;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
@@ -85,5 +87,40 @@ public class QueryPostRepository {
 		}
 
 		return keywordCondition;
+	}
+
+	public Optional<Post> findPreviousPost(Long id, LocalDateTime createdAt, Category category) {
+
+		Post result = queryFactory
+			.selectFrom(post)
+			.where(
+				post.createdAt.lt(createdAt)
+					.or(post.createdAt.eq(createdAt).and(post.id.lt(id))),
+				post.deletedAt.isNull(),
+				post.category.eq(category)
+			)
+			.orderBy(post.createdAt.desc(), post.id.desc())
+			.limit(1)
+			.fetchOne();
+
+		return Optional.ofNullable(result);
+	}
+
+	public Optional<Post> findNextPost(Long id, LocalDateTime createdAt, Category category) {
+		QPost post = QPost.post;
+
+		Post result = queryFactory
+			.selectFrom(post)
+			.where(
+				post.createdAt.gt(createdAt)
+					.or(post.createdAt.eq(createdAt).and(post.id.gt(id))),
+				post.deletedAt.isNull(),
+				post.category.eq(category)
+			)
+			.orderBy(post.createdAt.asc(), post.id.asc())
+			.limit(1)
+			.fetchOne();
+
+		return Optional.ofNullable(result);
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/post/infrastructure/QueryPostRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/infrastructure/QueryPostRepository.java
@@ -6,6 +6,7 @@ import static kgu.developers.domain.post.domain.QPost.post;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.querydsl.jpa.JPAExpressions;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
@@ -56,8 +57,12 @@ public class QueryPostRepository {
 	public void deleteAllByDeletedAtBefore(int retentionDays) {
 		LocalDateTime thresholdDate = LocalDateTime.now().minusDays(retentionDays);
 		queryFactory.delete(comment)
-			.where(comment.post.deletedAt.isNotNull()
-				.and(comment.post.deletedAt.before(thresholdDate)))
+			.where(comment.postId.in(
+				JPAExpressions.select(post.id)
+					.from(post)
+					.where(post.deletedAt.isNotNull()
+						.and(post.deletedAt.before(thresholdDate)))
+			))
 			.execute();
 
 		queryFactory.delete(post)

--- a/aics-domain/src/main/java/kgu/developers/domain/post/infrastructure/QueryPostRepository.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/infrastructure/QueryPostRepository.java
@@ -27,7 +27,7 @@ import lombok.RequiredArgsConstructor;
 public class QueryPostRepository {
 	private final JPAQueryFactory queryFactory;
 
-	public PaginatedListResponse findAllByTitleContainingAndCategoryOrderByCreatedAtDesc(List<String> keywords,
+	public PaginatedListResponse findAllByTitleContainingAndCategoryOrderByCreatedAtDescIdDesc(List<String> keywords,
 		Category category, Pageable pageable) {
 
 		BooleanExpression whereClause = post.deletedAt.isNull()
@@ -42,7 +42,7 @@ public class QueryPostRepository {
 		List<Post> posts = queryFactory.select(post)
 			.from(post)
 			.where(whereClause)
-			.orderBy(post.isPinned.desc(), post.createdAt.desc())
+			.orderBy(post.isPinned.desc(), post.createdAt.desc(), post.id.desc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();

--- a/aics-domain/src/main/java/kgu/developers/domain/user/application/query/UserQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/application/query/UserQueryService.java
@@ -15,6 +15,8 @@ import kgu.developers.domain.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -48,5 +50,9 @@ public class UserQueryService {
 
 	public List<User> getAllUsersByIds(List<String> ids) {
 		return userRepository.findAllById(ids);
+	}
+
+	public Map<String, String> getUserNameMapByIds(List<String> authorIds) {
+		return getAllUsersByIds(authorIds).stream().collect(Collectors.toMap(User::getId, User::getName));
 	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
@@ -4,11 +4,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import kgu.developers.common.domain.BaseRole;
 import kgu.developers.common.domain.BaseTimeEntity;
-import kgu.developers.domain.post.domain.Post;
 import kgu.developers.domain.user.exception.AlreadyDeletedUserException;
 import kgu.developers.domain.user.exception.DeptCodeNotValidException;
 import kgu.developers.domain.user.exception.DuplicatePasswordException;
@@ -24,14 +22,11 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.EnumType.STRING;
-import static jakarta.persistence.FetchType.LAZY;
 import static kgu.developers.common.domain.BaseRole.USER;
 import static kgu.developers.domain.user.domain.DeptCode.isValidDeptCode;
 import static lombok.AccessLevel.PROTECTED;

--- a/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/user/domain/User.java
@@ -68,10 +68,6 @@ public class User extends BaseTimeEntity implements UserDetails {
 	@Enumerated(STRING)
 	private Major major;
 
-	@Builder.Default
-	@OneToMany(mappedBy = "author", cascade = ALL, fetch = LAZY)
-	List<Post> posts = new ArrayList<>();
-
 	public static User create(String id, String password, String name, String email,
 							  String phone, Major major, PasswordEncoder passwordEncoder) {
 		validateDept(id, email);

--- a/aics-domain/src/testFixtures/java/comment/application/CommentCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/comment/application/CommentCommandServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import mock.repository.FakeFileRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,10 +38,11 @@ public class CommentCommandServiceTest {
 	@BeforeEach
 	public void init() {
 		FakePostRepository fakePostRepository = new FakePostRepository();
+		FakeFileRepository fakeFileRepository = new FakeFileRepository();
 		FakeUserRepository fakeUserRepository = new FakeUserRepository();
 		UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
 
-		initializeCommentCommandService(fakePostRepository, userQueryService);
+		initializeCommentCommandService(fakePostRepository, userQueryService, fakeFileRepository);
 		saveTestUserAndPost(fakeUserRepository, fakePostRepository);
 		setTestSecurityContext(userQueryService);
 	}
@@ -58,9 +60,10 @@ public class CommentCommandServiceTest {
 	}
 
 	private void initializeCommentCommandService(FakePostRepository fakePostRepository,
-												 UserQueryService userQueryService) {
+												 UserQueryService userQueryService,
+												 FakeFileRepository fakeFileRepository) {
 		commentCommandService = new CommentCommandService(
-			new PostQueryService(fakePostRepository),
+			new PostQueryService(fakePostRepository, fakeFileRepository),
 			userQueryService,
 			new FakeCommentRepository()
 		);

--- a/aics-domain/src/testFixtures/java/comment/application/CommentCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/comment/application/CommentCommandServiceTest.java
@@ -42,7 +42,7 @@ public class CommentCommandServiceTest {
 		FakeUserRepository fakeUserRepository = new FakeUserRepository();
 		UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
 
-		initializeCommentCommandService(fakePostRepository, userQueryService, fakeFileRepository);
+		initializeCommentCommandService(fakePostRepository, fakeFileRepository, fakeUserRepository, userQueryService);
 		saveTestUserAndPost(fakeUserRepository, fakePostRepository);
 		setTestSecurityContext(userQueryService);
 	}
@@ -55,15 +55,16 @@ public class CommentCommandServiceTest {
 		);
 		fakePostRepository.save(Post.create(
 			"SW 부트캠프 4기 교육생 모집", "SW전문인재양성사업단에서는 SW부트캠프 4기 교육생을 모집합니다.", NEWS,
-			User.builder().build(), null, false
+			"202412345", null, false
 		));
 	}
 
 	private void initializeCommentCommandService(FakePostRepository fakePostRepository,
-												 UserQueryService userQueryService,
-												 FakeFileRepository fakeFileRepository) {
+												 FakeFileRepository fakeFileRepository,
+												 FakeUserRepository fakeUserRepository,
+												 UserQueryService userQueryService) {
 		commentCommandService = new CommentCommandService(
-			new PostQueryService(fakePostRepository, fakeFileRepository),
+			new PostQueryService(fakePostRepository, fakeFileRepository, fakeUserRepository),
 			userQueryService,
 			new FakeCommentRepository()
 		);

--- a/aics-domain/src/testFixtures/java/comment/application/CommentCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/comment/application/CommentCommandServiceTest.java
@@ -95,8 +95,8 @@ public class CommentCommandServiceTest {
 	@DisplayName("updateComment는 댓글을 수정할 수 있다.")
 	public void updateComment_Success() {
 		// given
-		Comment comment = Comment.create("SW 부트캠프 모집이 정말 기대됩니다.", User.builder().build(),
-			Post.builder().build());
+		Comment comment = Comment.create("SW 부트캠프 모집이 정말 기대됩니다.", "202312345",
+			1L);
 		String updatedCommentContent = "SW 부트캠프 모집이 정말 기대됩니다. 4기 교육생 확정이 언제일까요?";
 
 		// when
@@ -110,8 +110,8 @@ public class CommentCommandServiceTest {
 	@DisplayName("deleteComment는 댓글을 삭제할 수 있다.")
 	public void deleteComment_Success() {
 		// given
-		Comment comment = Comment.create("SW 부트캠프 모집이 정말 기대됩니다.", User.builder().build(),
-			Post.builder().build());
+		Comment comment = Comment.create("SW 부트캠프 모집이 정말 기대됩니다.", "202312345",
+			1L);
 		assertNull(comment.getDeletedAt(), "삭제 전에는 deletedAt이 null이어야 합니다");
 
 		// when

--- a/aics-domain/src/testFixtures/java/comment/application/CommentCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/comment/application/CommentCommandServiceTest.java
@@ -55,7 +55,7 @@ public class CommentCommandServiceTest {
 		);
 		fakePostRepository.save(Post.create(
 			"SW 부트캠프 4기 교육생 모집", "SW전문인재양성사업단에서는 SW부트캠프 4기 교육생을 모집합니다.", NEWS,
-			"202412345", null, false
+			TEST_USER_ID, null, false
 		));
 	}
 
@@ -95,8 +95,8 @@ public class CommentCommandServiceTest {
 	@DisplayName("updateComment는 댓글을 수정할 수 있다.")
 	public void updateComment_Success() {
 		// given
-		Comment comment = Comment.create("SW 부트캠프 모집이 정말 기대됩니다.", "202312345",
-			1L);
+		Comment comment = Comment.create("SW 부트캠프 모집이 정말 기대됩니다.", TEST_USER_ID,
+			TEST_POST_ID);
 		String updatedCommentContent = "SW 부트캠프 모집이 정말 기대됩니다. 4기 교육생 확정이 언제일까요?";
 
 		// when
@@ -110,8 +110,8 @@ public class CommentCommandServiceTest {
 	@DisplayName("deleteComment는 댓글을 삭제할 수 있다.")
 	public void deleteComment_Success() {
 		// given
-		Comment comment = Comment.create("SW 부트캠프 모집이 정말 기대됩니다.", "202312345",
-			1L);
+		Comment comment = Comment.create("SW 부트캠프 모집이 정말 기대됩니다.", TEST_USER_ID,
+			TEST_POST_ID);
 		assertNull(comment.getDeletedAt(), "삭제 전에는 deletedAt이 null이어야 합니다");
 
 		// when

--- a/aics-domain/src/testFixtures/java/comment/application/CommentQueryServiceTest.java
+++ b/aics-domain/src/testFixtures/java/comment/application/CommentQueryServiceTest.java
@@ -55,7 +55,7 @@ public class CommentQueryServiceTest {
 	private static Post saveTestPost() {
 		FakePostRepository fakePostRepository = new FakePostRepository();
 		Post commentedPost = Post.create("SW 부트캠프 4기 교육생 모집",
-			"SW전문인재양성사업단에서는 SW부트캠프 4기 교육생을 모집합니다.", NEWS, User.builder().build(), null, false);
+			"SW전문인재양성사업단에서는 SW부트캠프 4기 교육생을 모집합니다.", NEWS, "202312345", null, false);
 		return fakePostRepository.save(commentedPost);
 	}
 

--- a/aics-domain/src/testFixtures/java/comment/application/CommentQueryServiceTest.java
+++ b/aics-domain/src/testFixtures/java/comment/application/CommentQueryServiceTest.java
@@ -28,6 +28,7 @@ public class CommentQueryServiceTest {
 	private static final Long SAVED_COMMENT_ID = 2L;
 	private static final Long NOT_EXIST_COMMENT_ID = 3L;
 	private static final Long TEST_POST_ID = 1L;
+	private static final String TEST_AUTHOR_ID = "202312345";
 
 	@BeforeEach
 	public void init() {
@@ -40,21 +41,21 @@ public class CommentQueryServiceTest {
 
 	private static void deletedComment(FakeCommentRepository fakeCommentRepository, Long postId) {
 		Comment commentToDelete = fakeCommentRepository.save(
-			Comment.create("삭제된 댓글 입니다", "202312345", postId)
+			Comment.create("삭제된 댓글 입니다", TEST_AUTHOR_ID, postId)
 		);
 		commentToDelete.delete();
 	}
 
 	private static void saveTestComment(FakeCommentRepository fakeCommentRepository, Long postId) {
 		fakeCommentRepository.save(
-			Comment.create(TARGET_COMMENT_CONTENT, "202312345", postId)
+			Comment.create(TARGET_COMMENT_CONTENT, TEST_AUTHOR_ID, postId)
 		);
 	}
 
 	private static Post saveTestPost() {
 		FakePostRepository fakePostRepository = new FakePostRepository();
 		Post commentedPost = Post.create("SW 부트캠프 4기 교육생 모집",
-			"SW전문인재양성사업단에서는 SW부트캠프 4기 교육생을 모집합니다.", NEWS, "202312345", null, false);
+			"SW전문인재양성사업단에서는 SW부트캠프 4기 교육생을 모집합니다.", NEWS, TEST_AUTHOR_ID, null, false);
 		return fakePostRepository.save(commentedPost);
 	}
 

--- a/aics-domain/src/testFixtures/java/comment/application/CommentQueryServiceTest.java
+++ b/aics-domain/src/testFixtures/java/comment/application/CommentQueryServiceTest.java
@@ -17,7 +17,6 @@ import kgu.developers.domain.comment.application.query.CommentQueryService;
 import kgu.developers.domain.comment.domain.Comment;
 import kgu.developers.domain.comment.exception.CommentNotFoundException;
 import kgu.developers.domain.post.domain.Post;
-import kgu.developers.domain.user.domain.User;
 import mock.repository.FakeCommentRepository;
 import mock.repository.FakePostRepository;
 
@@ -35,20 +34,20 @@ public class CommentQueryServiceTest {
 		FakeCommentRepository fakeCommentRepository = new FakeCommentRepository();
 		commentQueryService = new CommentQueryService(fakeCommentRepository);
 		Post post = saveTestPost();
-		deletedComment(fakeCommentRepository, post);
-		saveTestComment(fakeCommentRepository, post);
+		deletedComment(fakeCommentRepository, post.getId());
+		saveTestComment(fakeCommentRepository, post.getId());
 	}
 
-	private static void deletedComment(FakeCommentRepository fakeCommentRepository, Post post) {
+	private static void deletedComment(FakeCommentRepository fakeCommentRepository, Long postId) {
 		Comment commentToDelete = fakeCommentRepository.save(
-			Comment.create("삭제된 댓글 입니다", User.builder().build(), post)
+			Comment.create("삭제된 댓글 입니다", "202312345", postId)
 		);
 		commentToDelete.delete();
 	}
 
-	private static void saveTestComment(FakeCommentRepository fakeCommentRepository, Post post) {
+	private static void saveTestComment(FakeCommentRepository fakeCommentRepository, Long postId) {
 		fakeCommentRepository.save(
-			Comment.create(TARGET_COMMENT_CONTENT, User.builder().build(), post)
+			Comment.create(TARGET_COMMENT_CONTENT, "202312345", postId)
 		);
 	}
 

--- a/aics-domain/src/testFixtures/java/comment/domain/CommentDomainTest.java
+++ b/aics-domain/src/testFixtures/java/comment/domain/CommentDomainTest.java
@@ -44,7 +44,7 @@ public class CommentDomainTest {
 			"title",
 			"content.",
 			NEWS,
-			author,
+			author.getId(),
 			null,
 			false
 		);

--- a/aics-domain/src/testFixtures/java/comment/domain/CommentDomainTest.java
+++ b/aics-domain/src/testFixtures/java/comment/domain/CommentDomainTest.java
@@ -36,7 +36,7 @@ public class CommentDomainTest {
 	public void init() {
 		User author = getUser();
 		Post post = getPost(author);
-		comment = Comment.create(CONTENT, author, post);
+		comment = Comment.create(CONTENT, author.getId(), post.getId());
 	}
 
 	private Post getPost(User author) {

--- a/aics-domain/src/testFixtures/java/mock/FakeTestContainer.java
+++ b/aics-domain/src/testFixtures/java/mock/FakeTestContainer.java
@@ -73,7 +73,7 @@ public class FakeTestContainer {
 			() -> new UserCommandService(new BCryptPasswordEncoder(), get(UserRepository.class)));
 
 		suppliers.put(PostRepository.class, FakePostRepository::new);
-		suppliers.put(PostQueryService.class, () -> new PostQueryService(get(PostRepository.class), get(FileRepository.class)));
+		suppliers.put(PostQueryService.class, () -> new PostQueryService(get(PostRepository.class), get(FileRepository.class), get(UserRepository.class)));
 		suppliers.put(PostCommandService.class,
 			() -> new PostCommandService(get(UserQueryService.class), get(PostRepository.class), get(FileQueryService.class)));
 

--- a/aics-domain/src/testFixtures/java/mock/FakeTestContainer.java
+++ b/aics-domain/src/testFixtures/java/mock/FakeTestContainer.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import kgu.developers.domain.file.domain.FileRepository;
+import mock.repository.FakeFileRepository;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -71,6 +72,9 @@ public class FakeTestContainer {
 		suppliers.put(UserQueryService.class, () -> new UserQueryService(get(UserRepository.class)));
 		suppliers.put(UserCommandService.class,
 			() -> new UserCommandService(new BCryptPasswordEncoder(), get(UserRepository.class)));
+
+		suppliers.put(FileRepository.class, FakeFileRepository::new);
+		suppliers.put(FileQueryService.class, () -> new FileQueryService(get(FileRepository.class)));
 
 		suppliers.put(PostRepository.class, FakePostRepository::new);
 		suppliers.put(PostQueryService.class, () -> new PostQueryService(get(PostRepository.class), get(FileRepository.class), get(UserRepository.class)));

--- a/aics-domain/src/testFixtures/java/mock/FakeTestContainer.java
+++ b/aics-domain/src/testFixtures/java/mock/FakeTestContainer.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import kgu.developers.domain.file.domain.FileRepository;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -72,7 +73,7 @@ public class FakeTestContainer {
 			() -> new UserCommandService(new BCryptPasswordEncoder(), get(UserRepository.class)));
 
 		suppliers.put(PostRepository.class, FakePostRepository::new);
-		suppliers.put(PostQueryService.class, () -> new PostQueryService(get(PostRepository.class)));
+		suppliers.put(PostQueryService.class, () -> new PostQueryService(get(PostRepository.class), get(FileRepository.class)));
 		suppliers.put(PostCommandService.class,
 			() -> new PostCommandService(get(UserQueryService.class), get(PostRepository.class), get(FileQueryService.class)));
 

--- a/aics-domain/src/testFixtures/java/mock/TestContainer.java
+++ b/aics-domain/src/testFixtures/java/mock/TestContainer.java
@@ -113,7 +113,7 @@ public class TestContainer {
 		this.fileCommandService = new FileCommandService(fileRepository);
 
 		this.postRepository = new FakePostRepository();
-		this.postQueryService = new PostQueryService(postRepository);
+		this.postQueryService = new PostQueryService(postRepository,fileRepository);
 		this.postCommandService = new PostCommandService(userQueryService, postRepository, fileQueryService);
 
 		this.commentRepository = new FakeCommentRepository();

--- a/aics-domain/src/testFixtures/java/mock/TestContainer.java
+++ b/aics-domain/src/testFixtures/java/mock/TestContainer.java
@@ -113,7 +113,7 @@ public class TestContainer {
 		this.fileCommandService = new FileCommandService(fileRepository);
 
 		this.postRepository = new FakePostRepository();
-		this.postQueryService = new PostQueryService(postRepository,fileRepository);
+		this.postQueryService = new PostQueryService(postRepository, fileRepository, userRepository);
 		this.postCommandService = new PostCommandService(userQueryService, postRepository, fileQueryService);
 
 		this.commentRepository = new FakeCommentRepository();

--- a/aics-domain/src/testFixtures/java/mock/repository/FakeCommentRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/repository/FakeCommentRepository.java
@@ -20,8 +20,8 @@ public class FakeCommentRepository implements CommentRepository {
 		Comment newComment = Comment.builder()
 			.id(sequence.getAndIncrement())
 			.content(comment.getContent())
-			.author(comment.getAuthor())
-			.post(comment.getPost())
+			.authorId(comment.getAuthorId())
+			.postId(comment.getPostId())
 			.build();
 
 		TestEntityUtils.setCreatedAt(newComment, LocalDateTime.now());
@@ -33,7 +33,7 @@ public class FakeCommentRepository implements CommentRepository {
 	@Override
 	public List<Comment> findAllByPostIdAndDeletedAtIsNull(Long postId) {
 		return data.stream()
-			.filter(comment -> comment.getPost().getId().equals(postId)
+			.filter(comment -> comment.getPostId().equals(postId)
 				&& comment.getDeletedAt() == null)
 			.toList();
 	}

--- a/aics-domain/src/testFixtures/java/mock/repository/FakePostRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/repository/FakePostRepository.java
@@ -59,7 +59,9 @@ public class FakePostRepository implements PostRepository {
 					&& post.getCategory().equals(category)
 					&& post.getDeletedAt() == null
 			)
-			.sorted(Comparator.comparing(Post::getCreatedAt).reversed().thenComparing(Post::getId))
+			.sorted(Comparator.comparing(Post::isPinned, Comparator.reverseOrder())
+				.thenComparing(Post::getCreatedAt, Comparator.reverseOrder())
+				.thenComparing(Post::getId))
 			.collect(Collectors.toList());
 
 		int start = (int)pageable.getOffset();

--- a/aics-domain/src/testFixtures/java/mock/repository/FakePostRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/repository/FakePostRepository.java
@@ -40,7 +40,7 @@ public class FakePostRepository implements PostRepository {
 			.author(post.getAuthor())
 			.isPinned(post.isPinned())
 			.comments(new ArrayList<>(post.getComments()))
-			.file(post.getFile())
+			.fileId(post.getFileId())
 			.build();
 
 		TestEntityUtils.setCreatedAt(newPost, LocalDateTime.now());

--- a/aics-domain/src/testFixtures/java/mock/repository/FakePostRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/repository/FakePostRepository.java
@@ -49,7 +49,7 @@ public class FakePostRepository implements PostRepository {
 	}
 
 	@Override
-	public PaginatedListResponse<Post> findAllByTitleContainingAndCategoryOrderByCreatedAtDesc(
+	public PaginatedListResponse<Post> findAllByTitleContainingAndCategoryOrderByCreatedAtDescIdDesc(
 		List<String> keywords, Category category, Pageable pageable
 	) {
 		List<Post> filteredPosts = data.stream()
@@ -59,7 +59,7 @@ public class FakePostRepository implements PostRepository {
 					&& post.getCategory().equals(category)
 					&& post.getDeletedAt() == null
 			)
-			.sorted(Comparator.comparing(Post::getCreatedAt).reversed())
+			.sorted(Comparator.comparing(Post::getCreatedAt).reversed().thenComparing(Post::getId))
 			.collect(Collectors.toList());
 
 		int start = (int)pageable.getOffset();

--- a/aics-domain/src/testFixtures/java/mock/repository/FakePostRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/repository/FakePostRepository.java
@@ -91,18 +91,28 @@ public class FakePostRepository implements PostRepository {
 	}
 
 	@Override
-	public Optional<Post> findByPrevPost(LocalDateTime createdAt, Category category) {
+	public Optional<Post> findByPrevPost(Long postId, LocalDateTime createdAt, Category category) {
 		return data.stream()
-			.filter(post -> post.getCreatedAt().isBefore(createdAt) && post.getCategory().equals(category)
+			.filter(post -> isBeforePost(post, postId, createdAt) && post.getCategory().equals(category)
 				&& post.getDeletedAt() == null)
-			.max(Comparator.comparing(Post::getCreatedAt));
+			.max(Comparator.comparing(Post::getCreatedAt).thenComparing(Post::getId));
+	}
+
+	private boolean isBeforePost(Post post, Long postId, LocalDateTime createdAt) {
+		return post.getCreatedAt().isBefore(createdAt)
+			|| (post.getCreatedAt().equals(createdAt) && post.getId() < postId);
 	}
 
 	@Override
-	public Optional<Post> findByNextPost(LocalDateTime createdAt, Category category) {
+	public Optional<Post> findByNextPost(Long postId, LocalDateTime createdAt, Category category) {
 		return data.stream()
-			.filter(post -> post.getCreatedAt().isAfter(createdAt) && post.getCategory().equals(category)
+			.filter(post -> isAfterPost(post, postId, createdAt) && post.getCategory().equals(category)
 				&& post.getDeletedAt() == null)
-			.min(Comparator.comparing(Post::getCreatedAt));
+			.min(Comparator.comparing(Post::getCreatedAt).thenComparing(Post::getId));
+	}
+
+	private boolean isAfterPost(Post post, Long postId, LocalDateTime createdAt) {
+		return post.getCreatedAt().isAfter(createdAt)
+			|| (post.getCreatedAt().equals(createdAt) && post.getId() > postId);
 	}
 }

--- a/aics-domain/src/testFixtures/java/mock/repository/FakePostRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/repository/FakePostRepository.java
@@ -39,7 +39,6 @@ public class FakePostRepository implements PostRepository {
 			.category(post.getCategory())
 			.authorId(post.getAuthorId())
 			.isPinned(post.isPinned())
-			.comments(new ArrayList<>(post.getComments()))
 			.fileId(post.getFileId())
 			.build();
 

--- a/aics-domain/src/testFixtures/java/mock/repository/FakePostRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/repository/FakePostRepository.java
@@ -37,7 +37,7 @@ public class FakePostRepository implements PostRepository {
 			.content(post.getContent())
 			.views(post.getViews())
 			.category(post.getCategory())
-			.author(post.getAuthor())
+			.authorId(post.getAuthorId())
 			.isPinned(post.isPinned())
 			.comments(new ArrayList<>(post.getComments()))
 			.fileId(post.getFileId())

--- a/aics-domain/src/testFixtures/java/post/application/PostQueryServiceTest.java
+++ b/aics-domain/src/testFixtures/java/post/application/PostQueryServiceTest.java
@@ -2,6 +2,7 @@ package post.application;
 
 import static kgu.developers.domain.post.domain.Category.NEWS;
 import static kgu.developers.domain.post.domain.Category.NOTIFICATION;
+import static kgu.developers.domain.user.domain.Major.CSE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -38,7 +39,14 @@ public class PostQueryServiceTest {
 		fakeUserRepository = new FakeUserRepository();
 		postQueryService = new PostQueryService(fakePostRepository, fakeFileRepository, fakeUserRepository);
 
-		User author = User.builder().build();
+		User author = fakeUserRepository.save(User.builder()
+			.id("202411001")
+			.password("password1234")
+			.name("홍길동")
+			.email("hong1@kyonggi.ac.kr")
+			.phone("010-0000-0001")
+			.major(CSE)
+			.build());
 
 		fakePostRepository.save(Post.create(
 			"테스트용 제목1", "테스트용 내용1",

--- a/aics-domain/src/testFixtures/java/post/application/PostQueryServiceTest.java
+++ b/aics-domain/src/testFixtures/java/post/application/PostQueryServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 
+import mock.repository.FakeFileRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,11 +27,13 @@ import mock.repository.FakePostRepository;
 public class PostQueryServiceTest {
 	private PostQueryService postQueryService;
 	private FakePostRepository fakePostRepository;
+	private FakeFileRepository fakeFileRepository;
 
 	@BeforeEach
 	public void init() {
 		fakePostRepository = new FakePostRepository();
-		postQueryService = new PostQueryService(fakePostRepository);
+		fakeFileRepository = new FakeFileRepository();
+		postQueryService = new PostQueryService(fakePostRepository, fakeFileRepository);
 
 		User author = User.builder().build();
 

--- a/aics-domain/src/testFixtures/java/post/application/PostQueryServiceTest.java
+++ b/aics-domain/src/testFixtures/java/post/application/PostQueryServiceTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.util.List;
 
 import mock.repository.FakeFileRepository;
+import mock.repository.FakeUserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,39 +29,41 @@ public class PostQueryServiceTest {
 	private PostQueryService postQueryService;
 	private FakePostRepository fakePostRepository;
 	private FakeFileRepository fakeFileRepository;
+	private FakeUserRepository fakeUserRepository;
 
 	@BeforeEach
 	public void init() {
 		fakePostRepository = new FakePostRepository();
 		fakeFileRepository = new FakeFileRepository();
-		postQueryService = new PostQueryService(fakePostRepository, fakeFileRepository);
+		fakeUserRepository = new FakeUserRepository();
+		postQueryService = new PostQueryService(fakePostRepository, fakeFileRepository, fakeUserRepository);
 
 		User author = User.builder().build();
 
 		fakePostRepository.save(Post.create(
 			"테스트용 제목1", "테스트용 내용1",
-			NEWS, author, null, true
+			NEWS, author.getId(), null, true
 		));
 
 		fakePostRepository.save(Post.create(
 			"테스트용 제목2", "테스트용 내용2",
-			NEWS, author, null, false
+			NEWS, author.getId(), null, false
 		));
 
 		Post delete = fakePostRepository.save(Post.create(
 			"테스트용 제목3", "테스트용 내용3",
-			NEWS, author, null, false
+			NEWS, author.getId(), null, false
 		));
 		delete.delete();
 
 		fakePostRepository.save(Post.create(
 			"테스트용 제목4", "테스트용 내용4",
-			NOTIFICATION, author, null, false
+			NOTIFICATION, author.getId(), null, false
 		));
 
 		fakePostRepository.save(Post.create(
 			"테스트용 제목5", "테스트용 내용5",
-			NEWS, author, null, false
+			NEWS, author.getId(), null, false
 		));
 	}
 

--- a/aics-domain/src/testFixtures/java/post/domain/PostDomainTest.java
+++ b/aics-domain/src/testFixtures/java/post/domain/PostDomainTest.java
@@ -29,7 +29,7 @@ public class PostDomainTest {
 	@BeforeEach
 	public void init() {
 		User author = user();
-		post = Post.create(TITLE, CONTENT, NEWS, author, null, true);
+		post = Post.create(TITLE, CONTENT, NEWS, author.getId(), null, true);
 	}
 
 	private User user() {


### PR DESCRIPTION
## Summary

>- #251 

`User`, `Post`, `Comment`, `FileEntity` 간의 관계 매핑을 ID 참조 기반으로 변경하였습니다.

## Tasks

- `User`, `Post`, `Comment`, `FileEntity` 간의 관계 매핑을 ID 참조 기반으로 변경
- 이에 맞추어 조회 로직과 테스트 코드를 수정
