### PR TITLE
refactor/#261 Facade에서 FileEntity 대신 File의physicalPath를 사용하도록 수정

### DIFF
--- a/aics-api/src/main/java/kgu/developers/api/club/application/ClubFacade.java
+++ b/aics-api/src/main/java/kgu/developers/api/club/application/ClubFacade.java
@@ -27,6 +27,6 @@ public class ClubFacade {
 				.filter(Objects::nonNull)
 				.toList();
 
-		return ClubListResponse.from(clubs,fileQueryService.findFileEntityMapByIds(fileIds));
+		return ClubListResponse.from(clubs,fileQueryService.findPhysicalPathMapByIds(fileIds));
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/club/presentation/response/ClubDetailResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/club/presentation/response/ClubDetailResponse.java
@@ -28,14 +28,13 @@ public record ClubDetailResponse(
 		requiredMode = NOT_REQUIRED)
 	FilePathResponse file
 ) {
-	public static ClubDetailResponse from(Club club, FileEntity file) {
+	public static ClubDetailResponse from(Club club, String physicalPath) {
 		return ClubDetailResponse.builder()
 			.id(club.getId())
 			.name(club.getName())
 			.description(club.getDescription())
 			.site(club.getSite())
-			.file(file != null ?
-				FilePathResponse.from(file) : null)
+			.file(club.getFileId() != null ? FilePathResponse.of(club.getFileId(), physicalPath) : null)
 			.build();
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/club/presentation/response/ClubListResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/club/presentation/response/ClubListResponse.java
@@ -22,7 +22,7 @@ public record ClubListResponse(
 		requiredMode = REQUIRED)
 	List<ClubDetailResponse> contents
 ) {
-	public static ClubListResponse from(List<Club> clubs, Map<Long, FileEntity> fileMap) {
+	public static ClubListResponse from(List<Club> clubs, Map<Long,String> fileMap) {
 		return ClubListResponse.builder()
 			.contents(clubs.stream()
 				.map(club -> ClubDetailResponse.from(club,

--- a/aics-api/src/main/java/kgu/developers/api/lab/application/LabFacade.java
+++ b/aics-api/src/main/java/kgu/developers/api/lab/application/LabFacade.java
@@ -28,6 +28,6 @@ public class LabFacade {
 				.toList();
 
 
-		return LabListResponse.from(labs,fileQueryService.findFileEntityMapByIds(fileIds));
+		return LabListResponse.from(labs,fileQueryService.findPhysicalPathMapByIds(fileIds));
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/lab/presentation/response/LabDetailResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/lab/presentation/response/LabDetailResponse.java
@@ -5,7 +5,6 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import kgu.developers.domain.file.application.response.FilePathResponse;
-import kgu.developers.domain.file.domain.FileEntity;
 import kgu.developers.domain.lab.domain.Lab;
 import lombok.Builder;
 
@@ -33,15 +32,14 @@ public record LabDetailResponse(
 		requiredMode = NOT_REQUIRED)
 	FilePathResponse img
 ) {
-	public static LabDetailResponse from(Lab lab, FileEntity file) {
+	public static LabDetailResponse from(Lab lab, String physicalPath) {
 		return LabDetailResponse.builder()
 			.id(lab.getId())
 			.name(lab.getName())
 			.loc(lab.getLoc())
 			.site(lab.getSite())
 			.advisor(lab.getAdvisor())
-			.img(file != null ?
-				FilePathResponse.from(file) : null)
+			.img(lab.getFileId() != null ? FilePathResponse.of(lab.getFileId(), physicalPath) : null)
 			.build();
 	}
 }

--- a/aics-api/src/main/java/kgu/developers/api/lab/presentation/response/LabListResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/lab/presentation/response/LabListResponse.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import kgu.developers.domain.file.domain.FileEntity;
 import kgu.developers.domain.lab.domain.Lab;
 import lombok.Builder;
 
@@ -24,7 +23,7 @@ public record LabListResponse(
 		requiredMode = REQUIRED)
 	List<LabDetailResponse> contents
 ) {
-	public static LabListResponse from(List<Lab> labs, Map<Long, FileEntity> fileMap) {
+	public static LabListResponse from(List<Lab> labs, Map<Long, String> fileMap) {
 		return LabListResponse.builder()
 			.contents(labs.stream()
 				.map(lab -> LabDetailResponse.from(lab,fileMap.get(lab.getFileId())))

--- a/aics-domain/src/main/java/kgu/developers/domain/file/application/query/FileQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/file/application/query/FileQueryService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -19,11 +18,10 @@ public class FileQueryService {
 		return fileRepository.findById(id).orElse(null);
 	}
 
-
-	public Map<Long,FileEntity> findFileEntityMapByIds(List<Long> ids) {
+	public Map<Long,String> findPhysicalPathMapByIds(List<Long> ids) {
 		return fileRepository.findAllByIds(ids)
 				.stream()
-				.collect(Collectors.toMap(FileEntity::getId, Function.identity()));
+				.collect(Collectors.toMap(FileEntity::getId, FileEntity::getPhysicalPath));
 	}
 
 	public String getFilePhysicalPath(Long id) {


### PR DESCRIPTION
## Summary

>- #261 

**해당 PR에 대한 요약을 작성해주세요.**
현재 `clubFacde`, `labFacade`에서 FileEntity를 사용하는 문제가 있습니다.
`File Entity`관리를 `FileQueryService `계층에서 진행하도록 수정합니다

## Tasks

- Facade에서 FileEntity 대신 File의physicalPath를 사용하도록 수정


