### PR TITLE
feat/#KD-48 : Schedule API 구현

### DIFF
--- a/aics-admin/src/main/java/kgu/developers/admin/schedule/application/ScheduleAdminFacade.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/schedule/application/ScheduleAdminFacade.java
@@ -1,0 +1,52 @@
+package kgu.developers.admin.schedule.application;
+
+import kgu.developers.admin.schedule.presentation.request.ScheduleContentUpdateRequest;
+import kgu.developers.admin.schedule.presentation.request.ScheduleCreateRequest;
+import kgu.developers.admin.schedule.presentation.request.ScheduleUpdateRequest;
+import kgu.developers.admin.schedule.presentation.response.SchedulePersistResponse;
+import kgu.developers.domain.schedule.application.command.ScheduleService;
+import kgu.developers.domain.schedule.application.query.ScheduleQueryService;
+import kgu.developers.domain.schedule.domain.Schedule;
+import kgu.developers.domain.schedule.domain.SubmissionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class ScheduleAdminFacade {
+    private final ScheduleService scheduleService;
+    private final ScheduleQueryService scheduleQueryService;
+
+    public SchedulePersistResponse createSchedule(ScheduleCreateRequest request) {
+        Long id = scheduleService.createSchedule(
+                request.submissionType(),
+                request.title(),
+                request.content(),
+                request.startDate(),
+                request.endDate()
+        );
+        return SchedulePersistResponse.from(id);
+    }
+
+    public void updateSchedule(Long scheduleId, ScheduleUpdateRequest request) {
+        Schedule schedule = scheduleQueryService.getScheduleManagement(scheduleId);
+        scheduleService.updateSchedule(
+                schedule,
+                request.submissionType(),
+                request.title(),
+                request.startDate(),
+                request.endDate()
+        );
+    }
+
+    public void updateScheduleContent(SubmissionType submissionType, ScheduleContentUpdateRequest request) {
+        Schedule schedule =scheduleQueryService.getBySubmissionType(submissionType);
+        scheduleService.updateScheduleContent(schedule,request.content());
+    }
+
+    public void deleteSchedule(Long scheduleId) {
+        scheduleService.deleteSchedule(scheduleId);
+    }
+}

--- a/aics-admin/src/main/java/kgu/developers/admin/schedule/application/ScheduleAdminFacade.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/schedule/application/ScheduleAdminFacade.java
@@ -4,7 +4,7 @@ import kgu.developers.admin.schedule.presentation.request.ScheduleContentUpdateR
 import kgu.developers.admin.schedule.presentation.request.ScheduleCreateRequest;
 import kgu.developers.admin.schedule.presentation.request.ScheduleUpdateRequest;
 import kgu.developers.admin.schedule.presentation.response.SchedulePersistResponse;
-import kgu.developers.domain.schedule.application.command.ScheduleService;
+import kgu.developers.domain.schedule.application.command.ScheduleCommandService;
 import kgu.developers.domain.schedule.application.query.ScheduleQueryService;
 import kgu.developers.domain.schedule.domain.Schedule;
 import kgu.developers.domain.schedule.domain.SubmissionType;
@@ -16,11 +16,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class ScheduleAdminFacade {
-    private final ScheduleService scheduleService;
+    private final ScheduleCommandService scheduleCommandService;
     private final ScheduleQueryService scheduleQueryService;
 
     public SchedulePersistResponse createSchedule(ScheduleCreateRequest request) {
-        Long id = scheduleService.createSchedule(
+        Long id = scheduleCommandService.createSchedule(
                 request.submissionType(),
                 request.title(),
                 request.content(),
@@ -32,7 +32,7 @@ public class ScheduleAdminFacade {
 
     public void updateSchedule(Long scheduleId, ScheduleUpdateRequest request) {
         Schedule schedule = scheduleQueryService.getScheduleManagement(scheduleId);
-        scheduleService.updateSchedule(
+        scheduleCommandService.updateSchedule(
                 schedule,
                 request.submissionType(),
                 request.title(),
@@ -43,10 +43,10 @@ public class ScheduleAdminFacade {
 
     public void updateScheduleContent(SubmissionType submissionType, ScheduleContentUpdateRequest request) {
         Schedule schedule =scheduleQueryService.getBySubmissionType(submissionType);
-        scheduleService.updateScheduleContent(schedule,request.content());
+        scheduleCommandService.updateScheduleContent(schedule,request.content());
     }
 
     public void deleteSchedule(Long scheduleId) {
-        scheduleService.deleteSchedule(scheduleId);
+        scheduleCommandService.deleteSchedule(scheduleId);
     }
 }

--- a/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/ScheduleAdminController.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/ScheduleAdminController.java
@@ -1,0 +1,84 @@
+package kgu.developers.admin.schedule.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import kgu.developers.admin.schedule.presentation.request.ScheduleContentUpdateRequest;
+import kgu.developers.admin.schedule.presentation.request.ScheduleCreateRequest;
+import kgu.developers.admin.schedule.presentation.request.ScheduleUpdateRequest;
+import kgu.developers.admin.schedule.presentation.response.SchedulePersistResponse;
+import kgu.developers.domain.schedule.domain.SubmissionType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+
+@Tag(name = "Schedule", description = "일정 관리 API")
+public interface ScheduleAdminController {
+
+    @Operation(summary = "일정 생성 API", description = """
+		    - Description : 이 API는 일정을 생성합니다.
+		    - Assignee : 주윤빈
+		""")
+    @ApiResponse(
+            responseCode = "201",
+            content = @Content(schema = @Schema(implementation = SchedulePersistResponse.class)))
+	ResponseEntity<SchedulePersistResponse> createSchedule(
+			@Parameter(
+					description = "일정 생성 request 객체 입니다.",
+					required = true
+			)@Valid @RequestBody
+			ScheduleCreateRequest request
+	);
+
+	@Operation(summary = "일정 수정 API", description = """
+		    - Description : 이 API는 일정을 수정합니다.
+		    - Assignee : 주윤빈
+		""")
+	@ApiResponse(responseCode = "204")
+	ResponseEntity<Void> updateSchedule(
+			@Parameter(
+					description = "이 API는 제출 유형/제목/기간을 수정합니다.",
+					example = "1",
+					required = true
+			)@Positive @PathVariable Long scheduleId,
+			@Parameter(
+					description = "일정 수정 request 객체 입니다.",
+					required = true
+			)@Valid @RequestBody ScheduleUpdateRequest request
+	);
+
+	@Operation(summary = "유형별 본문 수정 API",description = """
+			-Description : 이 API는 제출 유형을 기준으로 본문만 수정합니다.
+			-Assignee : 주윤빈
+			""")
+	@ApiResponse(responseCode = "204")
+	ResponseEntity<Void> updateScheduleContent(
+			@Parameter(
+					description = "본문을 수정할 제출 유형입니다.",
+					example = "MIDTHESIS",
+					required = true
+			)@PathVariable SubmissionType submissionType,
+			@Parameter(description = "본문 수정 request 객체 입니다.",
+					required = true
+			)@Valid @RequestBody ScheduleContentUpdateRequest request
+	);
+
+	@Operation(summary = "일정 삭제 API", description = """
+		    - Description : 이 API는 일정을 삭제합니다.
+		    - Assignee : 주윤빈
+		""")
+	@ApiResponse(responseCode = "204")
+	ResponseEntity<Void> deleteSchedule(
+			@Parameter(
+					description = "삭제할 일정의 ID 입니다.",
+					example = "1",
+					required = true
+			)@Positive @PathVariable Long scheduleId
+	);
+}

--- a/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/ScheduleAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/ScheduleAdminControllerImpl.java
@@ -1,0 +1,61 @@
+package kgu.developers.admin.schedule.presentation;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import kgu.developers.admin.schedule.application.ScheduleAdminFacade;
+import kgu.developers.admin.schedule.presentation.request.ScheduleContentUpdateRequest;
+import kgu.developers.admin.schedule.presentation.request.ScheduleCreateRequest;
+import kgu.developers.admin.schedule.presentation.request.ScheduleUpdateRequest;
+import kgu.developers.admin.schedule.presentation.response.SchedulePersistResponse;
+import kgu.developers.domain.schedule.domain.SubmissionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/schedules")
+@PreAuthorize("hasRole('ROLE_ADMIN')")
+public class ScheduleAdminControllerImpl implements ScheduleAdminController {
+    private final ScheduleAdminFacade scheduleAdminFacade;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<SchedulePersistResponse> createSchedule(
+            @Valid @RequestBody ScheduleCreateRequest request
+    ){
+        SchedulePersistResponse response = scheduleAdminFacade.createSchedule(request);
+        return ResponseEntity.status(CREATED).body(response);
+    }
+
+    @Override
+    @PatchMapping("/{scheduleId}")
+    public ResponseEntity<Void> updateSchedule(
+            @Positive @PathVariable Long scheduleId,
+            @Valid @RequestBody ScheduleUpdateRequest request
+    ){
+        scheduleAdminFacade.updateSchedule(scheduleId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    @PatchMapping("/type/{submissionType}/content")
+    public ResponseEntity<Void> updateScheduleContent(
+            @PathVariable SubmissionType submissionType,
+            @Valid @RequestBody ScheduleContentUpdateRequest request
+            ){
+        scheduleAdminFacade.updateScheduleContent(submissionType, request);
+        return ResponseEntity.noContent().build();
+    }
+    @Override
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<Void> deleteSchedule(
+            @Positive @PathVariable Long scheduleId
+    ){
+        scheduleAdminFacade.deleteSchedule(scheduleId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/request/ScheduleContentUpdateRequest.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/request/ScheduleContentUpdateRequest.java
@@ -2,9 +2,11 @@ package kgu.developers.admin.schedule.presentation.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+@Builder
 public record ScheduleContentUpdateRequest(
     @Schema(description = "일정 내용", example = "매학기 개강 후 2주 이내에 신청서를 작성하여 접수해야합니다.",requiredMode = REQUIRED)
     @NotBlank

--- a/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/request/ScheduleContentUpdateRequest.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/request/ScheduleContentUpdateRequest.java
@@ -1,0 +1,14 @@
+package kgu.developers.admin.schedule.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record ScheduleContentUpdateRequest(
+    @Schema(description = "일정 내용", example = "매학기 개강 후 2주 이내에 신청서를 작성하여 접수해야합니다.",requiredMode = REQUIRED)
+    @NotBlank
+    String content
+) {
+
+}

--- a/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/request/ScheduleCreateRequest.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/request/ScheduleCreateRequest.java
@@ -3,9 +3,10 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import kgu.developers.domain.schedule.domain.SubmissionType;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
-
+@Builder
 public record ScheduleCreateRequest(
         @Schema(description = "제출 유형", example = "SUBMITTED", requiredMode = REQUIRED)
         @NotNull SubmissionType submissionType,
@@ -23,6 +24,7 @@ public record ScheduleCreateRequest(
         @NotNull LocalDateTime endDate
 ) {
         @AssertTrue(message = "종료 일시는 시작 일시 이후여야 합니다.")
+        @Schema(hidden = true)
         public boolean isValidDateRange() {
                 if (startDate ==null || endDate == null) {
                         return true;

--- a/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/request/ScheduleCreateRequest.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/request/ScheduleCreateRequest.java
@@ -1,0 +1,32 @@
+package kgu.developers.admin.schedule.presentation.request;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import kgu.developers.domain.schedule.domain.SubmissionType;
+
+import java.time.LocalDateTime;
+
+public record ScheduleCreateRequest(
+        @Schema(description = "제출 유형", example = "SUBMITTED", requiredMode = REQUIRED)
+        @NotNull SubmissionType submissionType,
+
+        @Schema(description = "일정 제목", example = "중간논문 제출 안내",requiredMode = REQUIRED)
+        @NotBlank @Size(max=100,message = "일정 제목은 100자 이내여야 합니다.") String title,
+
+        @Schema(description = "일정 내용", example = "매학기 개강 후 2주 이내에 신청서를 작성하여 접수해야합니다.",requiredMode = REQUIRED)
+        @NotBlank String content,
+
+        @Schema(description = "시작 일시", example = "2025-04-15T00:00:00", requiredMode = REQUIRED)
+        @NotNull LocalDateTime startDate,
+
+        @Schema(description = "종료 일시", example = "2025-12-31T23:59:59", requiredMode = REQUIRED)
+        @NotNull LocalDateTime endDate
+) {
+        @AssertTrue(message = "종료 일시는 시작 일시 이후여야 합니다.")
+        public boolean isValidDateRange() {
+                if (startDate ==null || endDate == null) {
+                        return true;
+                }
+                return !endDate.isBefore(startDate);
+        }
+}

--- a/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/request/ScheduleUpdateRequest.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/request/ScheduleUpdateRequest.java
@@ -3,11 +3,12 @@ package kgu.developers.admin.schedule.presentation.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import kgu.developers.domain.schedule.domain.SubmissionType;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
-
+@Builder
 public record ScheduleUpdateRequest(
         @Schema(description = "제출 유형", example = "SUBMITTED", requiredMode = REQUIRED)
         @NotNull
@@ -27,6 +28,7 @@ public record ScheduleUpdateRequest(
         LocalDateTime endDate
 ) {
         @AssertTrue(message = "종료 일시는 시작 일시 이후여야 합니다.")
+        @Schema(hidden = true)
         public boolean isValidDateRange() {
                 if (startDate ==null || endDate == null) {
                         return true;

--- a/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/request/ScheduleUpdateRequest.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/request/ScheduleUpdateRequest.java
@@ -1,0 +1,36 @@
+package kgu.developers.admin.schedule.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import kgu.developers.domain.schedule.domain.SubmissionType;
+
+import java.time.LocalDateTime;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record ScheduleUpdateRequest(
+        @Schema(description = "제출 유형", example = "SUBMITTED", requiredMode = REQUIRED)
+        @NotNull
+        SubmissionType submissionType,
+
+        @Schema(description = "일정 제목", example = "중간논문 제출 안내",requiredMode = REQUIRED)
+        @NotBlank @Size(max=100,message = "일정 제목은 100자 이내여야 합니다.")
+        String title,
+
+
+        @Schema(description = "시작 일시", example = "2025-04-15T00:00:00", requiredMode = REQUIRED)
+        @NotNull
+        LocalDateTime startDate,
+
+        @Schema(description = "종료 일시", example = "2025-12-31T23:59:59", requiredMode = REQUIRED)
+        @NotNull
+        LocalDateTime endDate
+) {
+        @AssertTrue(message = "종료 일시는 시작 일시 이후여야 합니다.")
+        public boolean isValidDateRange() {
+                if (startDate ==null || endDate == null) {
+                        return true;
+                }
+                return !endDate.isBefore(startDate);
+        }
+}

--- a/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/response/SchedulePersistResponse.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/schedule/presentation/response/SchedulePersistResponse.java
@@ -1,0 +1,18 @@
+package kgu.developers.admin.schedule.presentation.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+@Builder
+public record SchedulePersistResponse(
+    @Schema(description = "일정 id", example = "1", requiredMode = REQUIRED)
+    Long scheduleId
+) {
+    public static SchedulePersistResponse from(Long scheduleId) {
+        return SchedulePersistResponse.builder()
+                .scheduleId(scheduleId)
+                .build();
+    }
+}

--- a/aics-admin/src/testFixtures/java/schedule/application/ScheduleAdminFacadeTest.java
+++ b/aics-admin/src/testFixtures/java/schedule/application/ScheduleAdminFacadeTest.java
@@ -1,0 +1,197 @@
+package schedule.application;
+
+import static kgu.developers.domain.schedule.domain.SubmissionType.CERTIFICATE;
+import static kgu.developers.domain.schedule.domain.SubmissionType.MIDTHESIS;
+import static kgu.developers.domain.schedule.domain.SubmissionType.SUBMITTED;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kgu.developers.admin.schedule.application.ScheduleAdminFacade;
+import kgu.developers.admin.schedule.presentation.request.ScheduleContentUpdateRequest;
+import kgu.developers.admin.schedule.presentation.request.ScheduleCreateRequest;
+import kgu.developers.admin.schedule.presentation.request.ScheduleUpdateRequest;
+import kgu.developers.admin.schedule.presentation.response.SchedulePersistResponse;
+import kgu.developers.domain.schedule.application.command.ScheduleCommandService;
+import kgu.developers.domain.schedule.application.query.ScheduleQueryService;
+import kgu.developers.domain.schedule.domain.Schedule;
+import kgu.developers.domain.schedule.domain.SubmissionType;
+import kgu.developers.domain.schedule.exception.DuplicateScheduleTypeException;
+import kgu.developers.domain.schedule.exception.ScheduleNotFoundException;
+import mock.repository.FakeScheduleRepository;
+
+public class ScheduleAdminFacadeTest {
+
+	private static final LocalDateTime DEFAULT_START_DATE = LocalDateTime.of(2025, 1, 1, 0, 0);
+	private static final LocalDateTime DEFAULT_END_DATE = LocalDateTime.of(2025, 2, 1, 0, 0);
+
+	private ScheduleAdminFacade scheduleAdminFacade;
+	private FakeScheduleRepository fakeScheduleRepository;
+	private Long savedScheduleId;
+
+	@BeforeEach
+	public void init() {
+		fakeScheduleRepository = new FakeScheduleRepository();
+		scheduleAdminFacade = new ScheduleAdminFacade(
+			new ScheduleCommandService(fakeScheduleRepository),
+			new ScheduleQueryService(fakeScheduleRepository)
+		);
+
+		Schedule savedSchedule = fakeScheduleRepository.save(
+			Schedule.create(
+				SUBMITTED,
+				"신청 접수",
+				"본문",
+				DEFAULT_START_DATE,
+				DEFAULT_END_DATE
+			)
+		);
+		savedScheduleId = savedSchedule.getId();
+	}
+
+	@Test
+	@DisplayName("createSchedule은 일정을 생성하고 식별자를 반환한다")
+	void createSchedule_Success() {
+		// given
+		ScheduleCreateRequest request = ScheduleCreateRequest.builder()
+			.submissionType(MIDTHESIS)
+			.title("중간 논문 일정")
+			.content("중간 논문 본문")
+			.startDate(DEFAULT_START_DATE.plusMonths(1))
+			.endDate(DEFAULT_END_DATE.plusMonths(1))
+			.build();
+
+		// when
+		SchedulePersistResponse response = scheduleAdminFacade.createSchedule(request);
+
+		// then
+		assertEquals(2L, response.scheduleId());
+		assertEquals(2, fakeScheduleRepository.findAll().size());
+	}
+
+	@Test
+	@DisplayName("기존 제출 유형으로 생성하면 DuplicateScheduleTypeException을 발생시킨다")
+	void createSchedule_DuplicatedSubmissionType_ThrowsException() {
+		// given
+		ScheduleCreateRequest request = ScheduleCreateRequest.builder()
+			.submissionType(SUBMITTED)
+			.title("중복 일정")
+			.content("본문")
+			.startDate(DEFAULT_START_DATE)
+			.endDate(DEFAULT_END_DATE)
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> scheduleAdminFacade.createSchedule(request))
+			.isInstanceOf(DuplicateScheduleTypeException.class);
+	}
+
+	@Test
+	@DisplayName("updateSchedule은 제출 유형과 기간 정보를 수정한다")
+	void updateSchedule_Success() {
+		// given
+		ScheduleUpdateRequest request = ScheduleUpdateRequest.builder()
+			.submissionType(CERTIFICATE)
+			.title("수정 일정")
+			.startDate(DEFAULT_START_DATE.plusDays(3))
+			.endDate(DEFAULT_END_DATE.plusDays(5))
+			.build();
+
+		// when
+		scheduleAdminFacade.updateSchedule(savedScheduleId, request);
+
+		// then
+		Schedule updated = fakeScheduleRepository.findById(savedScheduleId).orElseThrow();
+		assertEquals(CERTIFICATE, updated.getSubmissionType());
+		assertEquals("수정 일정", updated.getTitle());
+		assertEquals(DEFAULT_START_DATE.plusDays(3), updated.getStartDate());
+		assertEquals(DEFAULT_END_DATE.plusDays(5), updated.getEndDate());
+	}
+
+	@Test
+	@DisplayName("다른 일정의 제출 유형으로 수정 시 DuplicateScheduleTypeException을 발생시킨다")
+	void updateSchedule_DuplicatedSubmissionType_ThrowsException() {
+		// given
+		fakeScheduleRepository.save(
+			Schedule.create(
+				MIDTHESIS,
+				"다른 일정",
+				"본문",
+				DEFAULT_START_DATE.plusMonths(2),
+				DEFAULT_END_DATE.plusMonths(2)
+			)
+		);
+
+		ScheduleUpdateRequest request = ScheduleUpdateRequest.builder()
+			.submissionType(MIDTHESIS)
+			.title("중복 수정")
+			.startDate(DEFAULT_START_DATE)
+			.endDate(DEFAULT_END_DATE)
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> scheduleAdminFacade.updateSchedule(savedScheduleId, request))
+			.isInstanceOf(DuplicateScheduleTypeException.class);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 id로 일정 수정 시 ScheduleNotFoundException을 발생시킨다")
+	void updateSchedule_NotFound_ThrowsException() {
+		// given
+		ScheduleUpdateRequest request = ScheduleUpdateRequest.builder()
+			.submissionType(SUBMITTED)
+			.title("수정 실패")
+			.startDate(DEFAULT_START_DATE)
+			.endDate(DEFAULT_END_DATE)
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> scheduleAdminFacade.updateSchedule(999L, request))
+			.isInstanceOf(ScheduleNotFoundException.class);
+	}
+
+	@Test
+	@DisplayName("updateScheduleContent는 제출 유형 기준으로 본문만 수정한다")
+	void updateScheduleContent_Success() {
+		// given
+		ScheduleContentUpdateRequest request = ScheduleContentUpdateRequest.builder()
+			.content("본문 수정")
+			.build();
+
+		// when
+		scheduleAdminFacade.updateScheduleContent(SUBMITTED, request);
+
+		// then
+		Schedule updated = fakeScheduleRepository.findById(savedScheduleId).orElseThrow();
+		assertEquals("본문 수정", updated.getContent());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 제출 유형으로 본문 수정 시 ScheduleNotFoundException을 발생시킨다")
+	void updateScheduleContent_NotFound_ThrowsException() {
+		// given
+		ScheduleContentUpdateRequest request = ScheduleContentUpdateRequest.builder()
+			.content("본문")
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> scheduleAdminFacade.updateScheduleContent(MIDTHESIS, request))
+			.isInstanceOf(ScheduleNotFoundException.class);
+	}
+
+	@Test
+	@DisplayName("deleteSchedule은 일정을 삭제한다")
+	void deleteSchedule_Success() {
+		// when
+		scheduleAdminFacade.deleteSchedule(savedScheduleId);
+
+		// then
+		assertTrue(fakeScheduleRepository.findById(savedScheduleId).isEmpty());
+	}
+}

--- a/aics-api/src/main/java/kgu/developers/api/schedule/application/ScheduleFacade.java
+++ b/aics-api/src/main/java/kgu/developers/api/schedule/application/ScheduleFacade.java
@@ -1,0 +1,32 @@
+package kgu.developers.api.schedule.application;
+
+import kgu.developers.domain.schedule.application.command.ScheduleService;
+import kgu.developers.domain.schedule.application.query.ScheduleQueryService;
+import kgu.developers.domain.schedule.domain.Schedule;
+import kgu.developers.domain.schedule.domain.SubmissionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScheduleFacade {
+    private final ScheduleQueryService scheduleQueryService;
+
+    public List<Schedule> findAll() {
+        return scheduleQueryService.getAllScheduleManagements();
+    }
+    public Schedule findBySubmissionType(SubmissionType submissionType) {
+        return scheduleQueryService.getBySubmissionType(submissionType);
+    }
+
+    public Schedule findById(Long id) {
+        return scheduleQueryService.getScheduleManagement(id);
+    }
+
+
+
+}

--- a/aics-api/src/main/java/kgu/developers/api/schedule/application/ScheduleFacade.java
+++ b/aics-api/src/main/java/kgu/developers/api/schedule/application/ScheduleFacade.java
@@ -1,6 +1,5 @@
 package kgu.developers.api.schedule.application;
 
-import kgu.developers.domain.schedule.application.command.ScheduleService;
 import kgu.developers.domain.schedule.application.query.ScheduleQueryService;
 import kgu.developers.domain.schedule.domain.Schedule;
 import kgu.developers.domain.schedule.domain.SubmissionType;

--- a/aics-api/src/main/java/kgu/developers/api/schedule/presentation/ScheduleController.java
+++ b/aics-api/src/main/java/kgu/developers/api/schedule/presentation/ScheduleController.java
@@ -1,0 +1,43 @@
+package kgu.developers.api.schedule.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kgu.developers.api.schedule.presentation.response.ScheduleListResponse;
+import kgu.developers.api.schedule.presentation.response.ScheduleSummaryResponse;
+import kgu.developers.api.schedule.presentation.response.ScheduleTypeContentResponse;
+import kgu.developers.domain.schedule.domain.SubmissionType;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Schedule", description = "일정관리 API")
+public interface ScheduleController {
+
+    @Operation(summary = "전체 일정 조회 API", description = """
+        - Description : 이 API는 모든 일정을 조회합니다.
+        - Assignee : 주윤빈
+    """)
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = ScheduleListResponse.class)))
+    ResponseEntity<ScheduleListResponse> getScheduleList();
+
+    @Operation(summary = "유형별 일정 본문 조회 API", description = """
+        - Description : 이 API는 제출유형별 본문만 조회합니다.
+        - Assignee : 주윤빈
+    """)
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = ScheduleTypeContentResponse.class)))
+    ResponseEntity<ScheduleTypeContentResponse> getSchedulesByType(SubmissionType type);
+
+    @Operation(summary = "단일 일정 조회 API", description = """
+        - Description : 이 API는 단일 일정을 조회합니다.
+        - Assignee : 주윤빈
+    """)
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = ScheduleSummaryResponse.class)))
+    ResponseEntity<ScheduleSummaryResponse> getScheduleById(Long id);
+}

--- a/aics-api/src/main/java/kgu/developers/api/schedule/presentation/ScheduleControllerImpl.java
+++ b/aics-api/src/main/java/kgu/developers/api/schedule/presentation/ScheduleControllerImpl.java
@@ -1,0 +1,43 @@
+package kgu.developers.api.schedule.presentation;
+
+import kgu.developers.api.schedule.application.ScheduleFacade;
+import kgu.developers.api.schedule.presentation.response.ScheduleListResponse;
+import kgu.developers.api.schedule.presentation.response.ScheduleSummaryResponse;
+import kgu.developers.api.schedule.presentation.response.ScheduleTypeContentResponse;
+import kgu.developers.domain.schedule.domain.SubmissionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/schedules")
+public class ScheduleControllerImpl implements ScheduleController {
+    private final ScheduleFacade scheduleFacade;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ScheduleListResponse> getScheduleList() {
+        LocalDateTime referenceTime = LocalDateTime.now();
+        return ResponseEntity.ok(ScheduleListResponse.from(scheduleFacade.findAll(),referenceTime));
+    }
+
+    @Override
+    @GetMapping("/type/{type}")
+    public ResponseEntity<ScheduleTypeContentResponse> getSchedulesByType(@PathVariable SubmissionType type){
+        return ResponseEntity.ok(ScheduleTypeContentResponse.from(scheduleFacade.findBySubmissionType(type)));
+    }
+
+    @Override
+    @GetMapping("/{id}")
+    public ResponseEntity<ScheduleSummaryResponse> getScheduleById(@PathVariable Long id){
+        LocalDateTime referenceTime = LocalDateTime.now();
+        return ResponseEntity.ok(ScheduleSummaryResponse.from(scheduleFacade.findById(id), referenceTime ));
+    }
+}

--- a/aics-api/src/main/java/kgu/developers/api/schedule/presentation/response/ScheduleListResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/schedule/presentation/response/ScheduleListResponse.java
@@ -1,0 +1,35 @@
+package kgu.developers.api.schedule.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kgu.developers.domain.schedule.domain.Schedule;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record ScheduleListResponse(
+    @Schema(description = "일정 리스트",
+                example = """
+        [{
+            "id": 1,
+            "submissionType": "MIDTHESIS",
+            "title": "중간논문 제출 안내",
+            "startDate": "2025-05-01",
+            "endDate": "2025-12-31",
+            "status": "IN_PROGRESS"
+        }]
+        """,
+                requiredMode = REQUIRED)
+    List<ScheduleSummaryResponse> contents
+) {
+    public static ScheduleListResponse from(List<Schedule> schedules,LocalDateTime referenceTime) {
+        return ScheduleListResponse.builder()
+                .contents(schedules.stream()
+                        .map(schedule -> ScheduleSummaryResponse.from(schedule,referenceTime))
+                        .toList())
+                .build();
+    }
+}

--- a/aics-api/src/main/java/kgu/developers/api/schedule/presentation/response/ScheduleSummaryResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/schedule/presentation/response/ScheduleSummaryResponse.java
@@ -1,0 +1,47 @@
+package kgu.developers.api.schedule.presentation.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kgu.developers.domain.schedule.domain.Schedule;
+import lombok.Builder;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+@Builder
+public record ScheduleSummaryResponse(
+    @Schema(description = "일정 id", example = "1", requiredMode = REQUIRED)
+    Long id,
+
+    @Schema(description = "제출 유형", example = "MIDTHESIS", requiredMode = REQUIRED)
+    String submissionType,
+
+    @Schema(description = "일정 제목", example = "중간논문 제출 안내", requiredMode = REQUIRED)
+    String title,
+
+    @Schema(description = "시작일", example = "2025-05-01", requiredMode = REQUIRED)
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    String startDate,
+
+    @Schema(description = "종료일", example = "2025-12-31", requiredMode = REQUIRED)
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    String endDate,
+
+    @Schema(description = "상태(대기/진행/마감)", example = "IN_PROGRESS", requiredMode = REQUIRED)
+    String status
+) {
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    public static ScheduleSummaryResponse from(Schedule schedule, LocalDateTime referenceTime) {
+        return ScheduleSummaryResponse.builder()
+                .id(schedule.getId())
+                .submissionType(schedule.getSubmissionType().name())
+                .title(schedule.getTitle())
+                .startDate(schedule.getStartDate().format(DATE_FORMATTER))
+                .endDate(schedule.getEndDate().format(DATE_FORMATTER))
+                .status(schedule.determineStatusAt(referenceTime).name())
+                .build();
+    }
+}

--- a/aics-api/src/main/java/kgu/developers/api/schedule/presentation/response/ScheduleTypeContentResponse.java
+++ b/aics-api/src/main/java/kgu/developers/api/schedule/presentation/response/ScheduleTypeContentResponse.java
@@ -1,0 +1,23 @@
+package kgu.developers.api.schedule.presentation.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kgu.developers.domain.schedule.domain.Schedule;
+import lombok.Builder;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+@Builder
+public record ScheduleTypeContentResponse(
+    @Schema(description = "제출 유형", example = "MIDTHESIS", requiredMode = REQUIRED)
+    String submissionType,
+
+    @Schema(description = "일정 본문 내용", example = "매학기 개강 후 2주 이내에 신청서를 작성하여 접수해야 합니다.",requiredMode = REQUIRED)
+    String content
+) {
+    public static ScheduleTypeContentResponse from(Schedule schedule) {
+        return ScheduleTypeContentResponse.builder()
+                .submissionType(schedule.getSubmissionType().name())
+                .content(schedule.getContent())
+                .build();
+    }
+}

--- a/aics-common/src/main/java/kgu/developers/common/config/SecurityConfig.java
+++ b/aics-common/src/main/java/kgu/developers/common/config/SecurityConfig.java
@@ -82,6 +82,7 @@ public class SecurityConfig {
 		"/api/v1/labs",
 		"/api/v1/comments",
 		"/api/v1/carousels",
+		"/api/v1/schedules",
 	};
 
 	CorsConfigurationSource corsConfigurationSource() {

--- a/aics-domain/src/main/java/kgu/developers/domain/schedule/application/command/ScheduleCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/schedule/application/command/ScheduleCommandService.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
-public class ScheduleService {
+public class ScheduleCommandService {
     private final ScheduleRepository scheduleRepository;
 
     public Long createSchedule(SubmissionType submissionType, String title, String content , LocalDateTime startDate, LocalDateTime endDate) {
@@ -45,6 +45,7 @@ public class ScheduleService {
         schedule.updateContent(content);
         scheduleRepository.save(schedule);
     }
+    @Transactional
     public void deleteSchedule(Long id) {
         Schedule schedule = scheduleRepository.findById(id)
                 .orElseThrow(ScheduleNotFoundException::new);

--- a/aics-domain/src/main/java/kgu/developers/domain/schedule/application/command/ScheduleService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/schedule/application/command/ScheduleService.java
@@ -5,6 +5,7 @@ import kgu.developers.domain.schedule.domain.Schedule;
 import kgu.developers.domain.schedule.domain.ScheduleRepository;
 import kgu.developers.domain.schedule.domain.SubmissionType;
 import kgu.developers.domain.schedule.exception.DuplicateScheduleTypeException;
+import kgu.developers.domain.schedule.exception.ScheduleNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,12 @@ public class ScheduleService {
     }
     @Transactional
     public void updateSchedule(Schedule schedule, SubmissionType submissionType , String title, LocalDateTime startDate, LocalDateTime endDate) {
+        if(!schedule.getSubmissionType().equals(submissionType)) {
+            scheduleRepository.findBySubmissionType(submissionType)
+                    .filter(other -> !other.getId().equals(schedule.getId()))
+                    .ifPresent(existing -> {
+                        throw new DuplicateScheduleTypeException();});
+        }
         schedule.updateSubmissionType(submissionType);
         schedule.updateTitle(title);
         schedule.updateStartDate(startDate);
@@ -39,6 +46,8 @@ public class ScheduleService {
         scheduleRepository.save(schedule);
     }
     public void deleteSchedule(Long id) {
+        Schedule schedule = scheduleRepository.findById(id)
+                .orElseThrow(ScheduleNotFoundException::new);
         scheduleRepository.deleteById(id);
     }
 

--- a/aics-domain/src/testFixtures/java/mock/repository/FakeScheduleRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/repository/FakeScheduleRepository.java
@@ -1,0 +1,63 @@
+package mock.repository;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import kgu.developers.domain.schedule.domain.Schedule;
+import kgu.developers.domain.schedule.domain.ScheduleRepository;
+import kgu.developers.domain.schedule.domain.SubmissionType;
+import kgu.developers.domain.schedule.infrastructure.entity.ScheduleJpaEntity;
+
+public class FakeScheduleRepository implements ScheduleRepository {
+	private final List<ScheduleJpaEntity> data = Collections.synchronizedList(new ArrayList<>());
+	private final AtomicLong sequence = new AtomicLong(1);
+
+	@Override
+	public Schedule save(Schedule schedule) {
+		Long id = schedule.getId() == null ? sequence.getAndIncrement() : schedule.getId();
+
+		ScheduleJpaEntity entity = ScheduleJpaEntity.builder()
+			.id(id)
+			.submissionType(schedule.getSubmissionType())
+			.title(schedule.getTitle())
+			.content(schedule.getContent())
+			.startDate(schedule.getStartDate())
+			.endDate(schedule.getEndDate())
+			.build();
+
+		data.removeIf(item -> item.getId().equals(id));
+		data.add(entity);
+		return entity.toDomain();
+	}
+
+	@Override
+	public void deleteById(Long id) {
+		data.removeIf(schedule -> schedule.getId().equals(id));
+	}
+
+	@Override
+	public Optional<Schedule> findById(Long id) {
+		return data.stream()
+				.filter(schedule -> schedule.getId().equals(id))
+				.findFirst()
+				.map(ScheduleJpaEntity::toDomain);
+	}
+
+	@Override
+	public List<Schedule> findAll() {
+		return data.stream()
+				.map(ScheduleJpaEntity :: toDomain)
+				.toList();
+	}
+
+	@Override
+	public Optional<Schedule> findBySubmissionType(SubmissionType submissionType) {
+		return data.stream()
+				.filter(schedule -> schedule.getSubmissionType()== submissionType)
+				.findFirst()
+				.map(ScheduleJpaEntity :: toDomain);
+	}
+}

--- a/aics-domain/src/testFixtures/java/schedule/application/ScheduleCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/schedule/application/ScheduleCommandServiceTest.java
@@ -1,0 +1,149 @@
+package schedule.application;
+
+import kgu.developers.domain.schedule.application.command.ScheduleCommandService;
+import kgu.developers.domain.schedule.domain.Schedule;
+import kgu.developers.domain.schedule.domain.SubmissionType;
+import kgu.developers.domain.schedule.exception.DuplicateScheduleTypeException;
+import kgu.developers.domain.schedule.exception.ScheduleNotFoundException;
+import mock.repository.FakeScheduleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ScheduleCommandServiceTest {
+    private ScheduleCommandService scheduleCommandService;
+    private FakeScheduleRepository fakeScheduleRepository;
+
+    private final LocalDateTime startDate = LocalDateTime.of(2024,2,1,9,0);
+    private final LocalDateTime endDate = startDate.plusDays(7);
+
+    @BeforeEach
+    void init(){
+        fakeScheduleRepository = new FakeScheduleRepository();
+        scheduleCommandService = new ScheduleCommandService(fakeScheduleRepository);
+    }
+
+    @Test
+    @DisplayName("createSchedule은 일정을 생성하고 ID를 반환한다.")
+    void createSchedule_Success(){
+        //given
+        Long id = scheduleCommandService.createSchedule(
+                SubmissionType.SUBMITTED,
+                "신청 일정",
+                "신청 일정 본문",
+                startDate,
+                endDate
+        );
+        //when
+        Schedule saved = fakeScheduleRepository.findById(id).orElseThrow();
+
+        //then
+        assertEquals(1L,id);
+        assertEquals("신청 일정", saved.getTitle());
+        assertEquals("신청 일정 본문", saved.getContent());
+    }
+
+    @Test
+    @DisplayName("같은 SubmissionType으로 createSchedule을 호출하면 예외가 발생한다.")
+    void createSchedule_DuplicateSubmissionType(){
+        //given
+        fakeScheduleRepository.save(
+                Schedule.create(SubmissionType.SUBMITTED,"기존 일정","내용",startDate,endDate)
+        );
+        //when & then
+        assertThrows(DuplicateScheduleTypeException.class, () ->
+                scheduleCommandService.createSchedule(
+                        SubmissionType.SUBMITTED,
+                        "중복 일정",
+                        "다른 내용",
+                        startDate.plusDays(1),
+                        endDate.plusDays(1)
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("updateSchedule은 제출타입과 기간, 제목을 갱신한다.")
+    void updateSchedule_Success(){
+        //given
+        Schedule schedule = fakeScheduleRepository.save(
+                Schedule.create(SubmissionType.SUBMITTED, "접수", "내용", startDate, endDate)
+        );
+        scheduleCommandService.updateSchedule(
+                schedule,
+                SubmissionType.MIDTHESIS,
+                "중간 점검",
+                startDate.plusWeeks(1),
+                endDate.plusWeeks(1)
+        );
+        //when
+        Schedule updated = fakeScheduleRepository.findById(schedule.getId()).orElseThrow();
+
+        //then
+        assertEquals(SubmissionType.MIDTHESIS, updated.getSubmissionType());
+        assertEquals("중간 점검", updated.getTitle());
+        assertEquals(startDate.plusWeeks(1), updated.getStartDate());
+
+    }
+    @Test
+    @DisplayName("이미 사용 중인 제출타입으로 updateSchedule을 호출하면 예외를 던진다")
+    void updateSchedule_DuplicateSubmissionTypeThrows() {
+        //given
+        Schedule first = fakeScheduleRepository.save(
+                Schedule.create(SubmissionType.SUBMITTED, "접수", "내용", startDate, endDate)
+        );
+        fakeScheduleRepository.save(
+                Schedule.create(SubmissionType.MIDTHESIS, "중간", "내용", startDate.plusDays(10), endDate.plusDays(10))
+        );
+
+        //when & then
+        assertThrows(DuplicateScheduleTypeException.class, () ->
+                scheduleCommandService.updateSchedule(
+                        first,
+                        SubmissionType.MIDTHESIS,
+                        "중간으로 변경",
+                        startDate.plusDays(1),
+                        endDate.plusDays(1)
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("updateScheduleContent는 내용을 수정한다")
+    void updateScheduleContent_Success() {
+        //given
+        Schedule schedule = fakeScheduleRepository.save(
+                Schedule.create(SubmissionType.SUBMITTED, "접수", "내용", startDate, endDate)
+        );
+        //when
+        scheduleCommandService.updateScheduleContent(schedule, "콘텐츠 업데이트");
+        //then
+        Schedule updated = fakeScheduleRepository.findById(schedule.getId()).orElseThrow();
+        assertEquals("콘텐츠 업데이트", updated.getContent());
+    }
+
+    @Test
+    @DisplayName("deleteSchedule은 일정을 삭제한다")
+    void deleteSchedule_Success() {
+        //given
+        Schedule schedule = fakeScheduleRepository.save(
+                Schedule.create(SubmissionType.SUBMITTED, "접수", "내용", startDate, endDate)
+        );
+        //when
+        scheduleCommandService.deleteSchedule(schedule.getId());
+        //then
+        assertTrue(fakeScheduleRepository.findById(schedule.getId()).isEmpty());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 ID로 deleteSchedule을 호출하면 예외가 발생한다")
+    void deleteSchedule_NotFound() {
+        assertThrows(ScheduleNotFoundException.class, () -> scheduleCommandService.deleteSchedule(999L));
+    }
+
+
+}

--- a/aics-domain/src/testFixtures/java/schedule/application/ScheduleQueryServiceTest.java
+++ b/aics-domain/src/testFixtures/java/schedule/application/ScheduleQueryServiceTest.java
@@ -1,0 +1,84 @@
+package schedule.application;
+
+import kgu.developers.domain.schedule.application.query.ScheduleQueryService;
+import kgu.developers.domain.schedule.domain.Schedule;
+import kgu.developers.domain.schedule.domain.SubmissionType;
+import kgu.developers.domain.schedule.exception.ScheduleNotFoundException;
+import mock.repository.FakeScheduleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ScheduleQueryServiceTest {
+    private ScheduleQueryService scheduleQueryService;
+    private FakeScheduleRepository fakeScheduleRepository;
+    private static final LocalDateTime baseStart = LocalDateTime.of(2024, 3, 1, 9, 0);
+
+    @BeforeEach
+    void init(){
+        fakeScheduleRepository = new FakeScheduleRepository();
+        scheduleQueryService = new ScheduleQueryService(fakeScheduleRepository);
+
+        fakeScheduleRepository.save(
+                Schedule.create(
+                        SubmissionType.SUBMITTED,
+                        "신청 일정",
+                        "신청 일정 본문",
+                        baseStart,
+                        baseStart.plusDays(3)
+                )
+        );
+
+        fakeScheduleRepository.save(
+                Schedule.create(
+                        SubmissionType.MIDTHESIS,
+                        "중간 논문",
+                        "중간 논문 설명",
+                        baseStart.plusDays(7),
+                        baseStart.plusDays(10)
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("getAllScheduleManagements는 전체 일정을 반환한다.")
+    void getAllScheduleManagements_Success() {
+        //given
+        //when
+        List<Schedule> result = scheduleQueryService.getAllScheduleManagements();
+        //then
+        assertEquals(2, result.size());
+        assertEquals(SubmissionType.SUBMITTED, result.get(0).getSubmissionType());
+        assertEquals(SubmissionType.MIDTHESIS, result.get(1).getSubmissionType());
+    }
+
+    @Test
+    @DisplayName("getScheduleManagement는 ID로 일정을 조회한다")
+    void getScheduleManagement_Success(){
+        Schedule schedule = scheduleQueryService.getScheduleManagement(1L);
+
+        assertEquals("신청 일정",schedule.getTitle());
+        assertEquals(SubmissionType.SUBMITTED, schedule.getSubmissionType());
+    }
+
+    @Test
+    @DisplayName("getScheduleManagement는 존재하지 않는 ID면 예외를 던집니다.")
+    void getScheduleManagement_NotFound() {
+        assertThrows(ScheduleNotFoundException.class, () -> scheduleQueryService.getScheduleManagement(99L));
+    }
+
+    @Test
+    @DisplayName("getBySubmissionType은 제출타입으로 일정을 찾는다")
+    void getBySubmissionType_Success() {
+        Schedule schedule = scheduleQueryService.getBySubmissionType(SubmissionType.MIDTHESIS);
+
+        assertEquals("중간 논문", schedule.getTitle());
+    }
+
+}

--- a/aics-domain/src/testFixtures/java/schedule/domain/ScheduleDomainTest.java
+++ b/aics-domain/src/testFixtures/java/schedule/domain/ScheduleDomainTest.java
@@ -1,0 +1,76 @@
+package schedule.domain;
+
+import kgu.developers.domain.schedule.domain.Schedule;
+import kgu.developers.domain.schedule.domain.ScheduleStatus;
+import kgu.developers.domain.schedule.domain.SubmissionType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+
+import java.time.LocalDateTime;
+
+public class ScheduleDomainTest {
+    private Schedule schedule;
+    private static final LocalDateTime startDate = LocalDateTime.of(2024,4,1,9,0) ;
+    private static final LocalDateTime endDate = startDate.plusDays(5);
+
+    @BeforeEach
+    void init(){
+        schedule  = Schedule.create(
+                SubmissionType.SUBMITTED,
+                "신청 일정",
+                "신청 관련 설명",
+                startDate,
+                endDate
+        );
+    }
+
+    @Test
+    @DisplayName("Schedule 객체를 올바르게 생성할 수 있다.")
+    void createSchedule_Success(){
+        assertEquals(SubmissionType.SUBMITTED, schedule.getSubmissionType());
+        assertEquals("신청 일정",schedule.getTitle());
+        assertEquals("신청 관련 설명", schedule.getContent());
+        assertEquals(startDate,schedule.getStartDate());
+        assertEquals(endDate,schedule.getEndDate());
+    }
+
+    @Test
+    @DisplayName("determineStatusAt은 대기, 진행 중, 종료 상태를 판별합니다.")
+    void determinStatusAt_ReturnsExpectedStatus(){
+        assertEquals(ScheduleStatus.PENDING, schedule.determineStatusAt(startDate.minusDays(1)));
+        assertEquals(ScheduleStatus.IN_PROGRESS, schedule.determineStatusAt(startDate.plusHours(1)));
+        assertEquals(ScheduleStatus.CLOSED, schedule.determineStatusAt(endDate.plusMinutes(1)));
+    }
+
+    @Test
+    @DisplayName("update 메서드는 제출타입과 기간, 타이틀을 수정할 수 있다.")
+    void updateScheduleFields_Success(){
+        LocalDateTime newStart = startDate.plusDays(10);
+        LocalDateTime newEnd = newStart.plusDays(3);
+
+        schedule.updateSubmissionType(SubmissionType.MIDTHESIS);
+        schedule.updateTitle("중간 점검");
+        schedule.updateStartDate(newStart);
+        schedule.updateEndDate(newEnd);
+
+        assertEquals(SubmissionType.MIDTHESIS, schedule.getSubmissionType());
+        assertEquals("중간 점검", schedule.getTitle());
+        assertEquals(newStart, schedule.getStartDate());
+        assertEquals(newEnd, schedule.getEndDate());
+
+    }
+
+    @Test
+    @DisplayName("updateContent는 내용을 변경한다")
+    void updateContent_Success() {
+        schedule.updateContent("세부 내용 변경");
+
+        assertEquals("세부 내용 변경", schedule.getContent());
+    }
+
+}


### PR DESCRIPTION
## Summary

>- #284 

논문 페이지에 들어갈 일정 관련 api 구현 했습니다.

## Tasks

- schedule 조회 api 구현
- schedule 관리용 api구현

## To Reviewer

- 일정 타입으로 본문 내용을 조회하고 
본문 내용을 수정하도록 기존에 구현 되었다고 해서 일정 타입이 중복 생성되는 것을 막았습니다.
- 일정 조회시 시작일자와 종료 일자,일정 타입, 일정 이름이 조회됩니다.
