### PR TITLE
Refactor/KD-55 GraduationUser 상세 조회 API가 졸업 상태를 포함하도록 수정

### DIFF
--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/application/GraduationUserAdminFacade.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/application/GraduationUserAdminFacade.java
@@ -128,7 +128,9 @@ public class GraduationUserAdminFacade {
     }
 
     public GraduationUserDetailResponse getGraduationUserById(Long graduationUserId) {
-        return GraduationUserDetailResponse.from(graduationUserQueryService.getById(graduationUserId));
+        GraduationUser graduationUser = graduationUserQueryService.getById(graduationUserId);
+        GraduationUserStatusResponse status = buildSubmissionStatus(graduationUser);
+        return GraduationUserDetailResponse.from(graduationUser, status);
     }
 
     public GraduationUserBatchDeleteResponse deleteGraduationUsers(GraduationUserBatchDeleteRequest request) {

--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/application/GraduationUserAdminFacade.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/application/GraduationUserAdminFacade.java
@@ -16,12 +16,14 @@ import kgu.developers.admin.graduationUser.presentation.response.GraduationUserS
 import kgu.developers.common.response.PaginatedListResponse;
 import kgu.developers.domain.certificate.application.command.CertificateCommandService;
 import kgu.developers.domain.certificate.application.query.CertificateQueryService;
+import kgu.developers.domain.certificate.domain.Certificate;
 import kgu.developers.domain.graduationUser.application.command.GraduationUserCommandService;
 import kgu.developers.domain.graduationUser.application.query.GraduationUserQueryService;
 import kgu.developers.domain.graduationUser.domain.GraduationType;
 import kgu.developers.domain.graduationUser.domain.GraduationUser;
 import kgu.developers.domain.thesis.application.command.ThesisCommandService;
 import kgu.developers.domain.thesis.application.query.ThesisQueryService;
+import kgu.developers.domain.thesis.domain.Thesis;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
@@ -90,36 +92,37 @@ public class GraduationUserAdminFacade {
     }
 
     private GraduationUserStatusResponse.Certificate buildCertificateStatus(Long certificateId) {
-        boolean submitted = certificateId != null;
-        boolean approval = false;
-        if(submitted) {
-            approval = certificateQueryService.isApproved(certificateId);
+        if (certificateId == null) {
+            return GraduationUserStatusResponse.Certificate.of(GraduationType.CERTIFICATE,false,false,null);
         }
 
-        return new GraduationUserStatusResponse.Certificate("CERTIFICATE", submitted, approval);
+        Certificate certificate = certificateQueryService.getById(certificateId);
+
+        return GraduationUserStatusResponse.Certificate.of(GraduationType.CERTIFICATE, true, certificate.isApproved(), certificate.getCreatedAt());
     }
 
     private GraduationUserStatusResponse.Thesis buildThesisStatus(Long middleThesisId, Long finalThesisId) {
 
-        boolean midThesisSubmitted = middleThesisId != null;
-        boolean midThesisapproval = false;
-        if(midThesisSubmitted) {
-            midThesisapproval = thesisQueryService.isApproved(middleThesisId);
+        GraduationUserStatusResponse.Thesis.Middle midThesisStatus;
+        GraduationUserStatusResponse.Thesis.Final finalThesisStatus;
+
+        if(middleThesisId == null) {
+            midThesisStatus = GraduationUserStatusResponse.Thesis.Middle.of(false, false, null);
+        } else {
+            Thesis midThesis = thesisQueryService.getById(middleThesisId);
+
+            midThesisStatus = GraduationUserStatusResponse.Thesis.Middle.of(true, midThesis.isApproved(), midThesis.getCreatedAt());
         }
 
-        GraduationUserStatusResponse.Thesis.Middle midStatus =
-                new GraduationUserStatusResponse.Thesis.Middle(midThesisSubmitted,midThesisapproval);
+        if(finalThesisId == null) {
+            finalThesisStatus = GraduationUserStatusResponse.Thesis.Final.of(false, false, null);
+        } else {
+            Thesis midThesis = thesisQueryService.getById(middleThesisId);
 
-        boolean finalThesisSubmitted = finalThesisId != null;
-        boolean finalThesisapproval = false;
-        if(finalThesisSubmitted) {
-            finalThesisapproval = thesisQueryService.isApproved(finalThesisId);
+            finalThesisStatus = GraduationUserStatusResponse.Thesis.Final.of(true, midThesis.isApproved(), midThesis.getCreatedAt());
         }
 
-        GraduationUserStatusResponse.Thesis.Final finalStatus =
-                new GraduationUserStatusResponse.Thesis.Final(finalThesisSubmitted,finalThesisapproval);
-
-        return new GraduationUserStatusResponse.Thesis("THESIS", midStatus, finalStatus);
+        return GraduationUserStatusResponse.Thesis.of(GraduationType.THESIS, midThesisStatus, finalThesisStatus);
     }
 
     public void deleteGraduationUser(Long id) {

--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserDetailResponse.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserDetailResponse.java
@@ -39,11 +39,13 @@ public record GraduationUserDetailResponse(
                 + "\"type\": \"THESIS\", "
                 + "\"midThesis\": {"
                     + "\"submitted\": true, "
-                    + "\"approval\": true"
+                    + "\"approval\": true, "
+                    + "\"createdAt\": \"2024-08-01\" "
                 + "}, "
                 + "\"finalThesis\": {"
                     + "\"submitted\": false, "
-                    + "\"approval\": false"
+                    + "\"approval\": false, "
+                    + "\"createdAt\": \"null\" "
                 + "}"
                 + "}",
         requiredMode = REQUIRED

--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserDetailResponse.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserDetailResponse.java
@@ -31,10 +31,28 @@ public record GraduationUserDetailResponse(
     String major,
 
     @Schema(description = "캡스톤 이수 여부", example = "true", requiredMode = REQUIRED)
-    Boolean capstoneCompletion
+    Boolean capstoneCompletion,
+
+    @Schema(
+        description = "졸업 요건 제출 및 승인 상태 (자격증 또는 논문)",
+        example = "{"
+                + "\"type\": \"THESIS\", "
+                + "\"midThesis\": {"
+                    + "\"submitted\": true, "
+                    + "\"approval\": true"
+                + "}, "
+                + "\"finalThesis\": {"
+                    + "\"submitted\": false, "
+                    + "\"approval\": false"
+                + "}"
+                + "}",
+        requiredMode = REQUIRED
+    )
+    GraduationUserStatusResponse status
 ) {
     public static GraduationUserDetailResponse from(
-        GraduationUser graduationUser
+        GraduationUser graduationUser,
+        GraduationUserStatusResponse status
     ) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
         return GraduationUserDetailResponse.builder()
@@ -45,6 +63,7 @@ public record GraduationUserDetailResponse(
             .advisor(graduationUser.getAdvisorProfessor())
             .major(graduationUser.getDepartment())
             .capstoneCompletion(graduationUser.getCapstoneCompletion())
+            .status(status)
             .build();
     }
 }

--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserStatusResponse.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserStatusResponse.java
@@ -1,6 +1,14 @@
 package kgu.developers.admin.graduationUser.presentation.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import kgu.developers.domain.graduationUser.domain.GraduationType;
+import lombok.Builder;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 /**
  * 졸업 대상자 상태 응답 인터페이스
@@ -11,6 +19,7 @@ public sealed interface GraduationUserStatusResponse
         permits GraduationUserStatusResponse.Certificate,
         GraduationUserStatusResponse.Thesis {
 
+    @Builder
     @Schema(description = "자격증 제출 상태")
     record Certificate(
             @Schema(description = "졸업 타입", example = "CERTIFICATE")
@@ -20,10 +29,25 @@ public sealed interface GraduationUserStatusResponse
             boolean submitted,
 
             @Schema(description = "승인 여부", example = "false")
-            boolean approval
+            boolean approval,
+
+            @Schema(description = "제출일", example = "2024-08-11", requiredMode = REQUIRED)
+            @DateTimeFormat(pattern = "yyyy-MM-dd")
+            String createdAt
+
     ) implements GraduationUserStatusResponse {
+        public static Certificate of(GraduationType type, boolean submitted, boolean approval, LocalDateTime createdAt) {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            return Certificate.builder()
+                .type(type.name())
+                .submitted(submitted)
+                .approval(approval)
+                .createdAt(createdAt.format(formatter))
+                .build();
+        }
     }
 
+    @Builder
     @Schema(description = "논문 제출 상태")
     record Thesis(
             @Schema(description = "졸업 타입", example = "THESIS")
@@ -35,23 +59,58 @@ public sealed interface GraduationUserStatusResponse
             @Schema(description = "최종 논문 상태")
             Final finalThesis
     ) implements GraduationUserStatusResponse {
+        public static Thesis of(GraduationType type, Middle midThesis, Final finalThesis) {
+            return Thesis.builder()
+                .type(type.name())
+                .midThesis(midThesis)
+                .finalThesis(finalThesis)
+                .build();
+        }
 
+        @Builder
         @Schema(description = "중간 논문 제출 상태")
         public record Middle(
                 @Schema(description = "파일 제출 여부", example = "true")
                 boolean submitted,
 
                 @Schema(description = "승인 여부", example = "true")
-                boolean approval
-        ) {}
+                boolean approval,
 
+                @Schema(description = "제출일", example = "2024-08-11", requiredMode = REQUIRED)
+                @DateTimeFormat(pattern = "yyyy-MM-dd")
+                String createdAt
+        ) {
+            public static Middle of(boolean submitted, boolean approval, LocalDateTime createdAt) {
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                return Middle.builder()
+                    .submitted(submitted)
+                    .approval(approval)
+                    .createdAt(createdAt.format(formatter))
+                    .build();
+            }
+        }
+
+        @Builder
         @Schema(description = "최종 논문 제출 상태")
         public record Final(
                 @Schema(description = "파일 제출 여부", example = "false")
                 boolean submitted,
 
                 @Schema(description = "승인 여부", example = "false")
-                boolean approval
-        ) {}
+                boolean approval,
+
+                @Schema(description = "제출일", example = "2024-08-11", requiredMode = REQUIRED)
+                @DateTimeFormat(pattern = "yyyy-MM-dd")
+                String createdAt
+        ) {
+            public static Final of(boolean submitted, boolean approval, LocalDateTime createdAt) {
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                return Final.builder()
+                    .submitted(submitted)
+                    .approval(approval)
+                    .createdAt(createdAt.format(formatter))
+                    .build();
+            }
+        }
     }
 }

--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserSummaryResponse.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserSummaryResponse.java
@@ -44,7 +44,10 @@ public record GraduationUserSummaryResponse(
     )
     GraduationUserStatusResponse status
 ) {
-    public static GraduationUserSummaryResponse of(GraduationUser graduationUser, GraduationUserStatusResponse status) {
+    public static GraduationUserSummaryResponse of(
+        GraduationUser graduationUser,
+        GraduationUserStatusResponse status
+    ) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
 
         return GraduationUserSummaryResponse.builder()

--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserSummaryResponse.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserSummaryResponse.java
@@ -33,11 +33,13 @@ public record GraduationUserSummaryResponse(
                     + "\"type\": \"THESIS\", "
                     + "\"midThesis\": {"
                         + "\"submitted\": true, "
-                        + "\"approval\": true"
+                        + "\"approval\": true, "
+                        + "\"createdAt\": \"2024-08-01\" "
                     + "}, "
                     + "\"finalThesis\": {"
                         + "\"submitted\": false, "
-                        + "\"approval\": false"
+                        + "\"approval\": false, "
+                        + "\"createdAt\": \"null\" "
                     + "}"
                     + "}",
             requiredMode = REQUIRED

--- a/aics-admin/src/testFixtures/java/graduationUser/application/GraduationUserAdminFacadeTest.java
+++ b/aics-admin/src/testFixtures/java/graduationUser/application/GraduationUserAdminFacadeTest.java
@@ -66,7 +66,7 @@ public class GraduationUserAdminFacadeTest {
     public void init() {
         FakeGraduationUserRepository fakeGraduationUserRepository = new FakeGraduationUserRepository();
         fakeUserRepository = new FakeUserRepository();
-        GraduationUserCommandService graduationUserCommandService = new GraduationUserCommandService(fakeGraduationUserRepository, fakeUserRepository);
+        GraduationUserCommandService graduationUserCommandService = new GraduationUserCommandService(fakeGraduationUserRepository);
 
         fakeThesisRepository = new FakeThesisRepository();
         fakeCertificateRepository = new FakeCertificateRepository();

--- a/aics-api/src/main/resources/db/data.sql
+++ b/aics-api/src/main/resources/db/data.sql
@@ -135,11 +135,11 @@ VALUES ('참여 신청 방법을 자세히 알고 싶습니다.', '2025-03-03 00
 INSERT INTO graduation_user (name, email, advisor_professor, graduation_type, graduation_date, capstone_completion,
                              mid_thesis_id, final_thesis_id, certificate_id, user_id, created_at, updated_at)
 VALUES
-    ('김철수', 'chulsoo@kyonggi.ac.kr', '이순신', '논문', '2028-02-01', true, 1, 2, NULL, '202512345', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-    ('이영희', 'younghee@kyonggi.ac.kr', '홍길동', '자격증', '2028-08-01', true, NULL, NULL, 1, '202512346', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-    ('박민수', 'minsu@kyonggi.ac.kr', '정약용', '논문', '2029-02-01', true, 3, NULL, NULL, '202512347', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-    ('정수진', 'sujin@kyonggi.ac.kr', '김이박', '논문', '2030-02-01', false, 4, 5, NULL, '202512349', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-    ('최동욱', 'dongwook@kyonggi.ac.kr', '이교수', '자격증', '2027-08-01', false, NULL, NULL, 2, '202512348', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+    ('김철수', 'chulsoo@kyonggi.ac.kr', '이순신', 'THESIS', '2028-02-01', true, 1, 2, NULL, '202512345', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    ('이영희', 'younghee@kyonggi.ac.kr', '홍길동', 'CERTIFICATE', '2028-08-01', true, NULL, NULL, 1, '202512346', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    ('박민수', 'minsu@kyonggi.ac.kr', '정약용', 'THESIS', '2029-02-01', true, 3, NULL, NULL, '202512347', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    ('정수진', 'sujin@kyonggi.ac.kr', '김이박', 'THESIS', '2030-02-01', false, 4, 5, NULL, '202512349', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    ('최동욱', 'dongwook@kyonggi.ac.kr', '이교수', 'CERTIFICATE', '2027-08-01', false, NULL, NULL, 2, '202512348', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- schedule
 INSERT INTO schedule (submission_type,  content, start_date, end_date, created_at, updated_at)

--- a/aics-api/src/main/resources/db/data.sql
+++ b/aics-api/src/main/resources/db/data.sql
@@ -132,14 +132,14 @@ VALUES ('참여 신청 방법을 자세히 알고 싶습니다.', '2025-03-03 00
        ('프로젝트 자료를 다운로드했습니다. 유익하네요.', '2025-03-03 07:01:00', '2025-03-03 07:01:00', 8, '202412347'),
        ('연구 참여 방법이 있나요?', '2025-03-03 07:02:00', '2025-03-03 07:02:00', 8, '202412346');
 
-INSERT INTO graduation_user (name, email, advisor_professor, graduation_type, graduation_date,
+INSERT INTO graduation_user (name, email, advisor_professor, graduation_type, graduation_date, capstone_completion,
                              mid_thesis_id, final_thesis_id, certificate_id, user_id, created_at, updated_at)
 VALUES
-    ('김철수', 'chulsoo@kyonggi.ac.kr', '이순신', '논문', '2028-02-28', 1, 2, NULL, '202512345', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-    ('이영희', 'younghee@kyonggi.ac.kr', '홍길동', '자격증', '2028-08-31', NULL, NULL, 1, '202512346', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-    ('박민수', 'minsu@kyonggi.ac.kr', '정약용', '논문', '2029-02-28', 3, NULL, NULL, '202512347', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-    ('정수진', 'sujin@kyonggi.ac.kr', '김이박', '논문', '2030-02-28', 4, 5, NULL, '202512349', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-    ('최동욱', 'dongwook@kyonggi.ac.kr', '이교수', '자격증', '2027-08-31', NULL, NULL, 2, '202512348', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+    ('김철수', 'chulsoo@kyonggi.ac.kr', '이순신', '논문', '2028-02-01', true, 1, 2, NULL, '202512345', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    ('이영희', 'younghee@kyonggi.ac.kr', '홍길동', '자격증', '2028-08-01', true, NULL, NULL, 1, '202512346', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    ('박민수', 'minsu@kyonggi.ac.kr', '정약용', '논문', '2029-02-01', true, 3, NULL, NULL, '202512347', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    ('정수진', 'sujin@kyonggi.ac.kr', '김이박', '논문', '2030-02-01', false, 4, 5, NULL, '202512349', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    ('최동욱', 'dongwook@kyonggi.ac.kr', '이교수', '자격증', '2027-08-01', false, NULL, NULL, 2, '202512348', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- schedule
 INSERT INTO schedule (submission_type,  content, start_date, end_date, created_at, updated_at)

--- a/aics-api/src/main/resources/db/schema.sql
+++ b/aics-api/src/main/resources/db/schema.sql
@@ -156,6 +156,7 @@ CREATE TABLE graduation_user
     CONSTRAINT graduation_type_check
             CHECK ((graduation_type)::TEXT = ANY (ARRAY ['THESIS', 'CERTIFICATE'])),
     graduation_date    DATE,
+    capstone_completion BOOLEAN,
     mid_thesis_id      BIGINT,
     final_thesis_id    BIGINT,
     certificate_id     BIGINT,

--- a/aics-api/src/testFixtures/java/graduationUser/application/GraduationUserFacadeTest.java
+++ b/aics-api/src/testFixtures/java/graduationUser/application/GraduationUserFacadeTest.java
@@ -35,7 +35,7 @@ public class GraduationUserFacadeTest {
         FakeUserRepository fakeUserRepository = new FakeUserRepository();
 
         GraduationUserQueryService graduationUserQueryService = new GraduationUserQueryService(fakeGraduationUserRepository,new FakeThesisRepository(), new FakeCertificateRepository(), new GraduationUserExcelImpl());
-        GraduationUserCommandService graduationUserCommandService = new GraduationUserCommandService(fakeGraduationUserRepository, fakeUserRepository);
+        GraduationUserCommandService graduationUserCommandService = new GraduationUserCommandService(fakeGraduationUserRepository);
 
         UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
         BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();

--- a/aics-domain/src/main/java/kgu/developers/domain/certificate/application/query/CertificateQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/certificate/application/query/CertificateQueryService.java
@@ -12,10 +12,6 @@ public class CertificateQueryService {
     private final CertificateRepository certificateRepository;
 
     public Certificate getById(Long id) {
-        return certificateRepository.findByIdAndDeletedAtIsNull(id)
-            .orElseThrow(CertificateNotFoundException::new);
-    }
-    public Certificate getById(Long id) {
         return  certificateRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(CertificateNotFoundException::new);
     }

--- a/aics-domain/src/main/java/kgu/developers/domain/certificate/application/query/CertificateQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/certificate/application/query/CertificateQueryService.java
@@ -1,5 +1,6 @@
 package kgu.developers.domain.certificate.application.query;
 
+import kgu.developers.domain.certificate.domain.Certificate;
 import kgu.developers.domain.certificate.domain.CertificateRepository;
 import kgu.developers.domain.certificate.exception.CertificateNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -10,8 +11,8 @@ import org.springframework.stereotype.Service;
 public class CertificateQueryService {
     private final CertificateRepository certificateRepository;
 
-    public boolean isApproved(Long id) {
-        return certificateRepository.findApprovalByIdAndDeletedAtIsNull(id)
-                .orElseThrow(CertificateNotFoundException::new);
+    public Certificate getById(Long id) {
+        return certificateRepository.findByIdAndDeletedAtIsNull(id)
+            .orElseThrow(CertificateNotFoundException::new);
     }
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/graduationUser/application/command/GraduationUserCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/graduationUser/application/command/GraduationUserCommandService.java
@@ -5,8 +5,6 @@ import kgu.developers.domain.graduationUser.domain.GraduationUser;
 import kgu.developers.domain.graduationUser.domain.GraduationUserRepository;
 import kgu.developers.domain.graduationUser.exception.GraduationUserIdDuplicateException;
 import kgu.developers.domain.schedule.domain.Schedule;
-import kgu.developers.domain.user.domain.UserRepository;
-import kgu.developers.domain.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +16,6 @@ import java.time.YearMonth;
 @RequiredArgsConstructor
 public class GraduationUserCommandService {
     private final GraduationUserRepository graduationUserRepository;
-    private final UserRepository userRepository;
 
     public Long createGraduationUser(String studentId, String name, String advisor, Boolean capstoneCompletion, String department, YearMonth graduationDate) {
         validateId(studentId);
@@ -29,8 +26,6 @@ public class GraduationUserCommandService {
     private void validateId(String id) {
         if (graduationUserRepository.findByUserIdAndDeletedAtIsNull(id).isPresent())
             throw new GraduationUserIdDuplicateException();
-        if(userRepository.findById(id).isEmpty())
-            throw new UserNotFoundException();
     }
 
     public void updateGraduationType(GraduationUser graduationUser, GraduationType type) {

--- a/aics-domain/src/main/java/kgu/developers/domain/thesis/application/query/ThesisQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/thesis/application/query/ThesisQueryService.java
@@ -1,5 +1,6 @@
 package kgu.developers.domain.thesis.application.query;
 
+import kgu.developers.domain.thesis.domain.Thesis;
 import kgu.developers.domain.thesis.domain.ThesisRepository;
 import kgu.developers.domain.thesis.exception.ThesisNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -10,8 +11,8 @@ import org.springframework.stereotype.Service;
 public class ThesisQueryService {
     private final ThesisRepository thesisRepository;
 
-    public boolean isApproved(Long id) {
-        return thesisRepository.findApprovalByIdAndDeletedAtIsNull(id)
-                .orElseThrow(ThesisNotFoundException::new);
+    public Thesis getById(Long id) {
+        return thesisRepository.findByIdAndDeletedAtIsNull(id)
+            .orElseThrow(ThesisNotFoundException::new);
     }
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/thesis/application/query/ThesisQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/thesis/application/query/ThesisQueryService.java
@@ -13,10 +13,6 @@ public class ThesisQueryService {
 
     public Thesis getById(Long id) {
         return thesisRepository.findByIdAndDeletedAtIsNull(id)
-            .orElseThrow(ThesisNotFoundException::new);
-    }
-    public Thesis getById(Long id) {
-        return thesisRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(ThesisNotFoundException::new);
     }
 }

--- a/aics-domain/src/testFixtures/java/graduationUser/application/GraduationUserCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/graduationUser/application/GraduationUserCommandServiceTest.java
@@ -38,7 +38,7 @@ public class GraduationUserCommandServiceTest {
     private void initializeGraduationUserCommandService() {
         fakeUserRepository = new FakeUserRepository();
         fakeGraduationUserRepository = new FakeGraduationUserRepository();
-        graduationUserCommandService = new GraduationUserCommandService(fakeGraduationUserRepository, fakeUserRepository);
+        graduationUserCommandService = new GraduationUserCommandService(fakeGraduationUserRepository);
         saveTestUser();
         graduationUser = fakeGraduationUserRepository.save(saveTestGraduationuser());
     }


### PR DESCRIPTION
## Summary

>- #298 

GraduationUserDetailResponse가 졸업 상태 정보를 포함하도록 상세 조회 API를 수정합니다.

## Tasks

- GraduationUserDetailResponse가 졸업 상태 정보를 포함하도록 상세 조회 API를 수정
- data.sql, schema.sql의 오류를 수정
