### PR TITLE
Fix/KD-56 Post 조회 로직 오류 수정

### DIFF
--- a/aics-domain/src/main/java/kgu/developers/domain/post/application/query/PostQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/post/application/query/PostQueryService.java
@@ -41,7 +41,9 @@ public class PostQueryService {
 		Post prevPost = postRepository.findByPrevPost(postId, timestamp, category).orElse(null);
 		Post nextPost = postRepository.findByNextPost(postId, timestamp, category).orElse(null);
 
-		FileModel file = fileRepository.findById(post.getFileId()).orElse(null);
+		Long fileId = post.getFileId();
+		FileModel file = fileId != null ? fileRepository.findById(fileId).orElse(null) : null;
+
 		User author = userRepository.findById(post.getAuthorId()).orElse(null);
 		PostTitleResponse prevPostResponse = PostTitleResponse.from(prevPost);
 		PostTitleResponse nextPostResponse = PostTitleResponse.from(nextPost);


### PR DESCRIPTION
## Summary

>- #302 

**해당 PR에 대한 요약을 작성해주세요.**
Post 상세 조회 및 전체 조회를 할때 fileID가 null인 Post를 요청해도 정상적으로 보낼수있도록 수정하였습니다.
## Tasks

- PostQueryService에 상세조회 로직 getPostByIdWithPrevAndNext 에서 fileID가 null일때 null을 반환할수있도록 수정

