### PR TITLE
refactor/KD-57

### DIFF
--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/application/GraduationUserAdminFacade.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/application/GraduationUserAdminFacade.java
@@ -93,12 +93,12 @@ public class GraduationUserAdminFacade {
 
     private GraduationUserStatusResponse.Certificate buildCertificateStatus(Long certificateId) {
         if (certificateId == null) {
-            return GraduationUserStatusResponse.Certificate.of(GraduationType.CERTIFICATE,false,false,null);
+            return GraduationUserStatusResponse.Certificate.of(GraduationType.CERTIFICATE,false, null,false,null);
         }
 
         Certificate certificate = certificateQueryService.getById(certificateId);
 
-        return GraduationUserStatusResponse.Certificate.of(GraduationType.CERTIFICATE, true, certificate.isApproved(), certificate.getCreatedAt());
+        return GraduationUserStatusResponse.Certificate.of(GraduationType.CERTIFICATE, true, certificate.getCertificateFileId(), certificate.isApproved(), certificate.getCreatedAt());
     }
 
     private GraduationUserStatusResponse.Thesis buildThesisStatus(Long middleThesisId, Long finalThesisId) {
@@ -107,19 +107,19 @@ public class GraduationUserAdminFacade {
         GraduationUserStatusResponse.Thesis.Final finalThesisStatus;
 
         if(middleThesisId == null) {
-            midThesisStatus = GraduationUserStatusResponse.Thesis.Middle.of(false, false, null);
+            midThesisStatus = GraduationUserStatusResponse.Thesis.Middle.of(false, null, false, null);
         } else {
             Thesis midThesis = thesisQueryService.getById(middleThesisId);
 
-            midThesisStatus = GraduationUserStatusResponse.Thesis.Middle.of(true, midThesis.isApproved(), midThesis.getCreatedAt());
+            midThesisStatus = GraduationUserStatusResponse.Thesis.Middle.of(true, midThesis.getThesisFileId(), midThesis.isApproved(), midThesis.getCreatedAt());
         }
 
         if(finalThesisId == null) {
-            finalThesisStatus = GraduationUserStatusResponse.Thesis.Final.of(false, false, null);
+            finalThesisStatus = GraduationUserStatusResponse.Thesis.Final.of(false, null, false, null);
         } else {
-            Thesis midThesis = thesisQueryService.getById(middleThesisId);
+            Thesis finalThesis = thesisQueryService.getById(finalThesisId);
 
-            finalThesisStatus = GraduationUserStatusResponse.Thesis.Final.of(true, midThesis.isApproved(), midThesis.getCreatedAt());
+            finalThesisStatus = GraduationUserStatusResponse.Thesis.Final.of(true, finalThesis.getThesisFileId(), finalThesis.isApproved(), finalThesis.getCreatedAt());
         }
 
         return GraduationUserStatusResponse.Thesis.of(GraduationType.THESIS, midThesisStatus, finalThesisStatus);

--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/application/GraduationUserAdminFacade.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/application/GraduationUserAdminFacade.java
@@ -98,7 +98,7 @@ public class GraduationUserAdminFacade {
 
         Certificate certificate = certificateQueryService.getById(certificateId);
 
-        return GraduationUserStatusResponse.Certificate.of(GraduationType.CERTIFICATE, true, certificate.getCertificateFileId(), certificate.isApproved(), certificate.getCreatedAt());
+        return GraduationUserStatusResponse.Certificate.of(GraduationType.CERTIFICATE, true, certificate.getId(), certificate.isApproved(), certificate.getCreatedAt());
     }
 
     private GraduationUserStatusResponse.Thesis buildThesisStatus(Long middleThesisId, Long finalThesisId) {
@@ -111,7 +111,7 @@ public class GraduationUserAdminFacade {
         } else {
             Thesis midThesis = thesisQueryService.getById(middleThesisId);
 
-            midThesisStatus = GraduationUserStatusResponse.Thesis.Middle.of(true, midThesis.getThesisFileId(), midThesis.isApproved(), midThesis.getCreatedAt());
+            midThesisStatus = GraduationUserStatusResponse.Thesis.Middle.of(true, midThesis.getId(), midThesis.isApproved(), midThesis.getCreatedAt());
         }
 
         if(finalThesisId == null) {
@@ -119,7 +119,7 @@ public class GraduationUserAdminFacade {
         } else {
             Thesis finalThesis = thesisQueryService.getById(finalThesisId);
 
-            finalThesisStatus = GraduationUserStatusResponse.Thesis.Final.of(true, finalThesis.getThesisFileId(), finalThesis.isApproved(), finalThesis.getCreatedAt());
+            finalThesisStatus = GraduationUserStatusResponse.Thesis.Final.of(true, finalThesis.getId(), finalThesis.isApproved(), finalThesis.getCreatedAt());
         }
 
         return GraduationUserStatusResponse.Thesis.of(GraduationType.THESIS, midThesisStatus, finalThesisStatus);

--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserStatusResponse.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserStatusResponse.java
@@ -25,6 +25,9 @@ public sealed interface GraduationUserStatusResponse
             @Schema(description = "졸업 타입", example = "CERTIFICATE")
             String type,
 
+            @Schema(description = "파일 id", example = "1")
+            Long id,
+
             @Schema(description = "파일 제출 여부", example = "true")
             boolean submitted,
 
@@ -36,13 +39,14 @@ public sealed interface GraduationUserStatusResponse
             String createdAt
 
     ) implements GraduationUserStatusResponse {
-        public static Certificate of(GraduationType type, boolean submitted, boolean approval, LocalDateTime createdAt) {
+        public static Certificate of(GraduationType type, boolean submitted,Long fileId, boolean approval, LocalDateTime createdAt) {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
             return Certificate.builder()
                 .type(type.name())
+                .id(fileId)
                 .submitted(submitted)
                 .approval(approval)
-                .createdAt(createdAt.format(formatter))
+                .createdAt(createdAt != null ? createdAt.format(formatter) : null)
                 .build();
         }
     }
@@ -73,6 +77,9 @@ public sealed interface GraduationUserStatusResponse
                 @Schema(description = "파일 제출 여부", example = "true")
                 boolean submitted,
 
+                @Schema(description = "파일 id", example = "1")
+                Long id,
+
                 @Schema(description = "승인 여부", example = "true")
                 boolean approval,
 
@@ -80,12 +87,13 @@ public sealed interface GraduationUserStatusResponse
                 @DateTimeFormat(pattern = "yyyy-MM-dd")
                 String createdAt
         ) {
-            public static Middle of(boolean submitted, boolean approval, LocalDateTime createdAt) {
+            public static Middle of(boolean submitted, Long fileId, boolean approval, LocalDateTime createdAt) {
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
                 return Middle.builder()
+                    .id(fileId)
                     .submitted(submitted)
                     .approval(approval)
-                    .createdAt(createdAt.format(formatter))
+                    .createdAt(createdAt != null ? createdAt.format(formatter) : null)
                     .build();
             }
         }
@@ -96,6 +104,9 @@ public sealed interface GraduationUserStatusResponse
                 @Schema(description = "파일 제출 여부", example = "false")
                 boolean submitted,
 
+                @Schema(description = "파일 id", example = "2")
+                Long id,
+
                 @Schema(description = "승인 여부", example = "false")
                 boolean approval,
 
@@ -103,12 +114,13 @@ public sealed interface GraduationUserStatusResponse
                 @DateTimeFormat(pattern = "yyyy-MM-dd")
                 String createdAt
         ) {
-            public static Final of(boolean submitted, boolean approval, LocalDateTime createdAt) {
+            public static Final of(boolean submitted, Long fileId, boolean approval, LocalDateTime createdAt) {
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
                 return Final.builder()
+                    .id(fileId)
                     .submitted(submitted)
                     .approval(approval)
-                    .createdAt(createdAt.format(formatter))
+                    .createdAt(createdAt != null ? createdAt.format(formatter) : null)
                     .build();
             }
         }

--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserStatusResponse.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserStatusResponse.java
@@ -39,11 +39,11 @@ public sealed interface GraduationUserStatusResponse
             String createdAt
 
     ) implements GraduationUserStatusResponse {
-        public static Certificate of(GraduationType type, boolean submitted,Long fileId, boolean approval, LocalDateTime createdAt) {
+        public static Certificate of(GraduationType type, boolean submitted,Long certificateId, boolean approval, LocalDateTime createdAt) {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
             return Certificate.builder()
                 .type(type.name())
-                .id(fileId)
+                .id(certificateId)
                 .submitted(submitted)
                 .approval(approval)
                 .createdAt(createdAt != null ? createdAt.format(formatter) : null)
@@ -87,10 +87,10 @@ public sealed interface GraduationUserStatusResponse
                 @DateTimeFormat(pattern = "yyyy-MM-dd")
                 String createdAt
         ) {
-            public static Middle of(boolean submitted, Long fileId, boolean approval, LocalDateTime createdAt) {
+            public static Middle of(boolean submitted, Long thesisId, boolean approval, LocalDateTime createdAt) {
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
                 return Middle.builder()
-                    .id(fileId)
+                    .id(thesisId)
                     .submitted(submitted)
                     .approval(approval)
                     .createdAt(createdAt != null ? createdAt.format(formatter) : null)
@@ -114,10 +114,10 @@ public sealed interface GraduationUserStatusResponse
                 @DateTimeFormat(pattern = "yyyy-MM-dd")
                 String createdAt
         ) {
-            public static Final of(boolean submitted, Long fileId, boolean approval, LocalDateTime createdAt) {
+            public static Final of(boolean submitted, Long thesisId, boolean approval, LocalDateTime createdAt) {
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
                 return Final.builder()
-                    .id(fileId)
+                    .id(thesisId)
                     .submitted(submitted)
                     .approval(approval)
                     .createdAt(createdAt != null ? createdAt.format(formatter) : null)

--- a/aics-api/src/main/resources/db/data.sql
+++ b/aics-api/src/main/resources/db/data.sql
@@ -133,13 +133,13 @@ VALUES ('참여 신청 방법을 자세히 알고 싶습니다.', '2025-03-03 00
        ('연구 참여 방법이 있나요?', '2025-03-03 07:02:00', '2025-03-03 07:02:00', 8, '202412346');
 
 INSERT INTO graduation_user (name, email, advisor_professor, graduation_type, graduation_date, capstone_completion,
-                             mid_thesis_id, final_thesis_id, certificate_id, user_id, created_at, updated_at)
+                             department, mid_thesis_id, final_thesis_id, certificate_id, user_id, created_at, updated_at)
 VALUES
-    ('김철수', 'chulsoo@kyonggi.ac.kr', '이순신', 'THESIS', '2028-02-01', true, 1, 2, NULL, '202512345', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-    ('이영희', 'younghee@kyonggi.ac.kr', '홍길동', 'CERTIFICATE', '2028-08-01', true, NULL, NULL, 1, '202512346', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-    ('박민수', 'minsu@kyonggi.ac.kr', '정약용', 'THESIS', '2029-02-01', true, 3, NULL, NULL, '202512347', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-    ('정수진', 'sujin@kyonggi.ac.kr', '김이박', 'THESIS', '2030-02-01', false, 4, 5, NULL, '202512349', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-    ('최동욱', 'dongwook@kyonggi.ac.kr', '이교수', 'CERTIFICATE', '2027-08-01', false, NULL, NULL, 2, '202512348', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+    ('김철수', 'chulsoo@kyonggi.ac.kr', '이순신', 'THESIS', '2028-02-01', true,"컴퓨터공학전공", 1, 2, NULL, '202512345', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    ('이영희', 'younghee@kyonggi.ac.kr', '홍길동', 'CERTIFICATE', '2028-08-01',true, "인공지능전공", NULL, NULL, 1, '202512346', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    ('박민수', 'minsu@kyonggi.ac.kr', '정약용', 'THESIS', '2029-02-01', true, "컴퓨터공학전공", 3, NULL, NULL, '202512347', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    ('정수진', 'sujin@kyonggi.ac.kr', '김이박', 'THESIS', '2030-02-01', false,"컴퓨터공학전공", 4, 5, NULL, '202512349', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    ('최동욱', 'dongwook@kyonggi.ac.kr', '이교수', 'CERTIFICATE', '2027-08-01', false,"SW안전보안전공", NULL, NULL, 2, '202512348', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- schedule
 INSERT INTO schedule (submission_type,  content, start_date, end_date, created_at, updated_at)

--- a/aics-api/src/main/resources/db/schema.sql
+++ b/aics-api/src/main/resources/db/schema.sql
@@ -157,6 +157,7 @@ CREATE TABLE graduation_user
             CHECK ((graduation_type)::TEXT = ANY (ARRAY ['THESIS', 'CERTIFICATE'])),
     graduation_date    DATE,
     capstone_completion BOOLEAN,
+    department         VARCHAR(255),
     mid_thesis_id      BIGINT,
     final_thesis_id    BIGINT,
     certificate_id     BIGINT,


### PR DESCRIPTION
## Summary

> #304 

상세 조회를 할 경우 Thesis 혹은 Certificate의 id를 반환하지 않아 각 파일의 상세 조회가 불가능하여 추가로 반환하도록 API를 변경하였습니다.

## Tasks

- [ ] GraduationUserStatusResponse이 파일 Id를 포함하도록 변경
- [ ] 현재 schema.sql과 data.sql이 graduationUser의 department 컬럼을 포함하도록 변경
- [ ] 졸업 논문 파일을 제출하지 않았을 경우 createdAt이 null를 반환하도록 변경
