### PR TITLE
fix: GraduationUserControllerImpl의 PreAuthorize 제거

### DIFF
--- a/aics-api/src/main/java/kgu/developers/api/graduationUser/presentation/GraduationUserControllerImpl.java
+++ b/aics-api/src/main/java/kgu/developers/api/graduationUser/presentation/GraduationUserControllerImpl.java
@@ -7,7 +7,6 @@ import kgu.developers.api.graduationUser.presentation.request.GraduationUserEmai
 import kgu.developers.api.graduationUser.presentation.response.MyGraduationUserResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@PreAuthorize("hasRole('ROLE_USER')")
 @RequestMapping("/api/v1/graduation-users")
 public class GraduationUserControllerImpl implements GraduationUserController {
 


### PR DESCRIPTION
## Summary

>- #310 

ADMIN 권한의 계정이 GraduationUser API에 접근 거부되는 오류를 수정하였습니다.

## Tasks

- GraduationUserControllerImpl의 PreAutorize를 제거
