### PR TITLE
fix/KD-64 논문/자격증 제출 시 유효성 검사 추가

### DIFF
--- a/aics-admin/src/testFixtures/java/graduationUser/application/GraduationUserAdminFacadeTest.java
+++ b/aics-admin/src/testFixtures/java/graduationUser/application/GraduationUserAdminFacadeTest.java
@@ -28,6 +28,7 @@ import kgu.developers.domain.schedule.application.query.ScheduleQueryService;
 import kgu.developers.domain.thesis.application.command.ThesisCommandService;
 import kgu.developers.domain.thesis.application.query.ThesisQueryService;
 import kgu.developers.domain.thesis.domain.Thesis;
+import kgu.developers.domain.user.application.query.UserQueryService;
 import kgu.developers.domain.user.domain.User;
 import mock.repository.FakeCertificateRepository;
 import mock.repository.FakeFileRepository;
@@ -71,8 +72,10 @@ public class GraduationUserAdminFacadeTest {
         fakeThesisRepository = new FakeThesisRepository();
         fakeCertificateRepository = new FakeCertificateRepository();
 
+        UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
+
         GraduationUserExcel graduationUserExcel = new GraduationUserExcelImpl();
-        GraduationUserQueryService graduationUserQueryService = new GraduationUserQueryService(fakeGraduationUserRepository, fakeThesisRepository, fakeCertificateRepository, graduationUserExcel);
+        GraduationUserQueryService graduationUserQueryService = new GraduationUserQueryService(userQueryService, fakeGraduationUserRepository, fakeThesisRepository, fakeCertificateRepository, graduationUserExcel);
 
         FakeFileRepository fakeFileRepository = new FakeFileRepository();
         FakeScheduleRepository fakeScheduleRepository = new FakeScheduleRepository();
@@ -89,14 +92,16 @@ public class GraduationUserAdminFacadeTest {
             fakeThesisRepository,
             fileStorageService,
             fileCommandService,
-            scheduleQueryService
+            scheduleQueryService,
+            graduationUserQueryService
         );
 
         CertificateCommandService certificateCommandService = new CertificateCommandService(
             fakeCertificateRepository,
             fileStorageService,
             fileCommandService,
-            scheduleQueryService
+            scheduleQueryService,
+            graduationUserQueryService
         );
 
         fakeThesisRepository.save(

--- a/aics-api/src/main/java/kgu/developers/api/certificate/application/CertificateFacade.java
+++ b/aics-api/src/main/java/kgu/developers/api/certificate/application/CertificateFacade.java
@@ -4,7 +4,6 @@ import kgu.developers.domain.certificate.application.command.CertificateCommandS
 import kgu.developers.domain.graduationUser.application.command.GraduationUserCommandService;
 import kgu.developers.domain.graduationUser.application.query.GraduationUserQueryService;
 import kgu.developers.domain.graduationUser.domain.GraduationUser;
-import kgu.developers.domain.user.application.query.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,16 +13,13 @@ import org.springframework.web.multipart.MultipartFile;
 public class CertificateFacade {
 
     private final CertificateCommandService certificateCommandService;
-    private final UserQueryService userQueryService;
     private final GraduationUserQueryService graduationUserQueryService;
     private final GraduationUserCommandService graduationUserCommandService;
 
     public Long submitCertificate(MultipartFile file, Long scheduleId) {
         Long certificateId = certificateCommandService.submitCertificate(file,scheduleId);
-        String userId = userQueryService.getMyId();
-        GraduationUser graduationUser = graduationUserQueryService.getByUserId(userId);
+        GraduationUser graduationUser = graduationUserQueryService.me();
         graduationUserCommandService.updateCertificate(graduationUser, certificateId);
         return certificateId;
     }
-
 }

--- a/aics-api/src/main/java/kgu/developers/api/graduationUser/application/GraduationUserFacade.java
+++ b/aics-api/src/main/java/kgu/developers/api/graduationUser/application/GraduationUserFacade.java
@@ -5,7 +5,6 @@ import kgu.developers.domain.graduationUser.application.command.GraduationUserCo
 import kgu.developers.domain.graduationUser.application.query.GraduationUserQueryService;
 import kgu.developers.domain.graduationUser.domain.GraduationType;
 import kgu.developers.domain.graduationUser.domain.GraduationUser;
-import kgu.developers.domain.user.application.query.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -14,25 +13,19 @@ import org.springframework.stereotype.Component;
 public class GraduationUserFacade {
     private final GraduationUserQueryService graduationUserQueryService;
     private final GraduationUserCommandService graduationUserCommandService;
-    private final UserQueryService userQueryService;
 
     public void updateGraduationType(GraduationType type) {
-        String userId = userQueryService.getMyId();
-        GraduationUser graduationUser = graduationUserQueryService.getByUserId(userId);
-        graduationUser.validateAccessPermission(userQueryService.getMyId());
+        GraduationUser graduationUser = graduationUserQueryService.me();
         graduationUserCommandService.updateGraduationType(graduationUser,type);
     }
 
     public void updateGraduationUserEmail(String email) {
-        String userId = userQueryService.getMyId();
-        GraduationUser graduationUser = graduationUserQueryService.getByUserId(userId);
-        graduationUser.validateAccessPermission(userQueryService.getMyId());
+        GraduationUser graduationUser = graduationUserQueryService.me();
         graduationUserCommandService.updateGraduationUserEmail(graduationUser,email);
     }
 
     public MyGraduationUserResponse getMyGraduationUser() {
-        String userId = userQueryService.getMyId();
-        GraduationUser graduationUser = graduationUserQueryService.getByUserId(userId);
+        GraduationUser graduationUser = graduationUserQueryService.me();
         return MyGraduationUserResponse.from(graduationUser);
     }
 }

--- a/aics-api/src/main/java/kgu/developers/api/thesis/application/ThesisFacade.java
+++ b/aics-api/src/main/java/kgu/developers/api/thesis/application/ThesisFacade.java
@@ -6,7 +6,6 @@ import kgu.developers.domain.graduationUser.domain.GraduationUser;
 import kgu.developers.domain.schedule.application.query.ScheduleQueryService;
 import kgu.developers.domain.schedule.domain.Schedule;
 import kgu.developers.domain.thesis.application.command.ThesisCommandService;
-import kgu.developers.domain.user.application.query.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,15 +15,13 @@ import org.springframework.web.multipart.MultipartFile;
 public class ThesisFacade {
 
     private final ThesisCommandService thesisCommandService;
-    private final UserQueryService userQueryService;
     private final GraduationUserQueryService graduationUserQueryService;
     private final ScheduleQueryService scheduleQueryService;
     private final GraduationUserCommandService graduationUserCommandService;
 
     public Long submitThesis(MultipartFile file, Long scheduleId) {
         Long thesisId = thesisCommandService.submitThesis(file,scheduleId);
-        String userId = userQueryService.getMyId();
-        GraduationUser graduationUser = graduationUserQueryService.getByUserId(userId);
+        GraduationUser graduationUser = graduationUserQueryService.me();
 
         Schedule schedule = scheduleQueryService.getScheduleManagement(scheduleId);
 

--- a/aics-api/src/testFixtures/java/graduationUser/application/GraduationUserFacadeTest.java
+++ b/aics-api/src/testFixtures/java/graduationUser/application/GraduationUserFacadeTest.java
@@ -33,13 +33,18 @@ public class GraduationUserFacadeTest {
     public void init() {
         fakeGraduationUserRepository = new FakeGraduationUserRepository();
         FakeUserRepository fakeUserRepository = new FakeUserRepository();
+        UserQueryService userQueryService = new UserQueryService(new FakeUserRepository());
 
-        GraduationUserQueryService graduationUserQueryService = new GraduationUserQueryService(fakeGraduationUserRepository,new FakeThesisRepository(), new FakeCertificateRepository(), new GraduationUserExcelImpl());
+        GraduationUserQueryService graduationUserQueryService = new GraduationUserQueryService(
+            userQueryService,
+            fakeGraduationUserRepository,
+            new FakeThesisRepository(),
+            new FakeCertificateRepository(),
+            new GraduationUserExcelImpl());
+
         GraduationUserCommandService graduationUserCommandService = new GraduationUserCommandService(fakeGraduationUserRepository);
-
-        UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
         BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-        graduationuserFacade = new GraduationUserFacade(graduationUserQueryService,graduationUserCommandService,userQueryService);
+        graduationuserFacade = new GraduationUserFacade(graduationUserQueryService,graduationUserCommandService);
 
         User user = fakeUserRepository.save(User.builder()
             .id("202411345")

--- a/aics-api/src/testFixtures/java/graduationUser/application/GraduationUserFacadeTest.java
+++ b/aics-api/src/testFixtures/java/graduationUser/application/GraduationUserFacadeTest.java
@@ -33,7 +33,7 @@ public class GraduationUserFacadeTest {
     public void init() {
         fakeGraduationUserRepository = new FakeGraduationUserRepository();
         FakeUserRepository fakeUserRepository = new FakeUserRepository();
-        UserQueryService userQueryService = new UserQueryService(new FakeUserRepository());
+        UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
 
         GraduationUserQueryService graduationUserQueryService = new GraduationUserQueryService(
             userQueryService,

--- a/aics-auth/src/testFixtures/java/auth/application/AuthServiceTest.java
+++ b/aics-auth/src/testFixtures/java/auth/application/AuthServiceTest.java
@@ -33,18 +33,24 @@ public class AuthServiceTest {
 		FakeUserRepository fakeUserRepository = new FakeUserRepository();
 		FakeRefreshTokenRepository fakeRefreshTokenRepository = new FakeRefreshTokenRepository();
 
+		UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
+
+		GraduationUserQueryService graduationUserQueryService = new GraduationUserQueryService(
+			userQueryService,
+			new FakeGraduationUserRepository(),
+			new FakeThesisRepository(),
+			new FakeCertificateRepository(),
+			new GraduationUserExcelImpl()
+		);
+
 		authService = new AuthService(
-			new UserQueryService(fakeUserRepository),
+			userQueryService,
 			new BCryptPasswordEncoder(),
 			TokenProvider.builder()
 				.jwtProperties(new JwtProperties("testIssuer", "testSecretKey"))
 				.build(),
 			fakeRefreshTokenRepository,
-			new GraduationUserQueryService(
-					new FakeGraduationUserRepository(),
-					new FakeThesisRepository(),
-					new FakeCertificateRepository(),
-					new GraduationUserExcelImpl())
+			graduationUserQueryService
 		);
 
 		user = fakeUserRepository.save(User.builder()

--- a/aics-common/src/main/java/kgu/developers/common/exception/GlobalExceptionHandler.java
+++ b/aics-common/src/main/java/kgu/developers/common/exception/GlobalExceptionHandler.java
@@ -39,7 +39,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	@ExceptionHandler(CustomException.class)
 	protected ResponseEntity<ExceptionResponse> handleCustomException(CustomException exception) {
-		System.out.println(exception.getCode());
 		if (exception.isServerError())
 			eventPublisher.publishEvent(exception);
 		ExceptionResponse response = ExceptionResponse.from(exception);

--- a/aics-common/src/main/java/kgu/developers/common/exception/GlobalExceptionHandler.java
+++ b/aics-common/src/main/java/kgu/developers/common/exception/GlobalExceptionHandler.java
@@ -1,13 +1,7 @@
 package kgu.developers.common.exception;
 
-import static kgu.developers.common.exception.AdminExceptionCode.NOT_ADMIN;
-import static kgu.developers.common.exception.GlobalExceptionCode.INVALID_INPUT;
-import static kgu.developers.common.exception.GlobalExceptionCode.SERVER_ERROR;
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.MessageSourceResolvable;
@@ -23,8 +17,13 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static kgu.developers.common.exception.AdminExceptionCode.NOT_ADMIN;
+import static kgu.developers.common.exception.GlobalExceptionCode.INVALID_INPUT;
+import static kgu.developers.common.exception.GlobalExceptionCode.SERVER_ERROR;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 
 @Slf4j
 @RestControllerAdvice
@@ -40,6 +39,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	@ExceptionHandler(CustomException.class)
 	protected ResponseEntity<ExceptionResponse> handleCustomException(CustomException exception) {
+		System.out.println(exception.getCode());
 		if (exception.isServerError())
 			eventPublisher.publishEvent(exception);
 		ExceptionResponse response = ExceptionResponse.from(exception);

--- a/aics-domain/src/main/java/kgu/developers/domain/certificate/application/command/CertificateCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/certificate/application/command/CertificateCommandService.java
@@ -1,17 +1,24 @@
 package kgu.developers.domain.certificate.application.command;
 
+import kgu.developers.domain.certificate.domain.Certificate;
+import kgu.developers.domain.certificate.domain.CertificateRepository;
+import kgu.developers.domain.certificate.exception.CertificateInvalidGraduationTypeException;
 import kgu.developers.domain.certificate.exception.CertificateNotFoundException;
+import kgu.developers.domain.certificate.exception.CertificateNotInSubmissionPeriodException;
+import kgu.developers.domain.file.application.command.FileCommandService;
+import kgu.developers.domain.file.domain.FileDomain;
+import kgu.developers.domain.file.infrastructure.repository.FileStorageService;
+import kgu.developers.domain.graduationUser.application.query.GraduationUserQueryService;
+import kgu.developers.domain.graduationUser.domain.GraduationType;
+import kgu.developers.domain.graduationUser.domain.GraduationUser;
+import kgu.developers.domain.schedule.application.query.ScheduleQueryService;
+import kgu.developers.domain.schedule.domain.Schedule;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import kgu.developers.domain.certificate.domain.Certificate;
-import kgu.developers.domain.certificate.domain.CertificateRepository;
-import kgu.developers.domain.file.application.command.FileCommandService;
-import kgu.developers.domain.file.domain.FileDomain;
-import kgu.developers.domain.file.infrastructure.repository.FileStorageService;
-import kgu.developers.domain.schedule.application.query.ScheduleQueryService;
-import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
 
 @Service
 @Transactional
@@ -21,11 +28,25 @@ public class CertificateCommandService {
 	private final FileStorageService fileStorageService;
 	private final FileCommandService fileCommandService;
 	private final ScheduleQueryService scheduleQueryService;
+	private final GraduationUserQueryService graduationUserQueryService;
 
 	public Long submitCertificate(MultipartFile file, Long scheduleId) {
+		Schedule schedule = scheduleQueryService.getScheduleManagement(scheduleId);
+		LocalDateTime referenceTime = LocalDateTime.now();
+
+
+		if(!schedule.isInProgress(referenceTime)) {
+			throw new CertificateNotInSubmissionPeriodException();
+		}
+
+		GraduationUser graduationUser = graduationUserQueryService.me();
+
+		if(graduationUser.getGraduationType() != GraduationType.CERTIFICATE) {
+			throw new CertificateInvalidGraduationTypeException();
+		}
+
 		String storedPath = fileStorageService.store(file, FileDomain.CERTIFICATE);
 		Long fileId = fileCommandService.saveFile(file, storedPath).getId();
-		scheduleQueryService.checkExistsOrThrow(scheduleId);
 
 		Certificate certificate = Certificate.create(scheduleId, fileId);
 		return certificateRepository.save(certificate);

--- a/aics-domain/src/main/java/kgu/developers/domain/certificate/application/command/CertificateCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/certificate/application/command/CertificateCommandService.java
@@ -32,17 +32,17 @@ public class CertificateCommandService {
 
 	public Long submitCertificate(MultipartFile file, Long scheduleId) {
 		Schedule schedule = scheduleQueryService.getScheduleManagement(scheduleId);
-		LocalDateTime referenceTime = LocalDateTime.now();
-
-
-		if(!schedule.isInProgress(referenceTime)) {
-			throw new CertificateNotInSubmissionPeriodException();
-		}
 
 		GraduationUser graduationUser = graduationUserQueryService.me();
 
 		if(graduationUser.getGraduationType() != GraduationType.CERTIFICATE) {
 			throw new CertificateInvalidGraduationTypeException();
+		}
+
+		LocalDateTime referenceTime = LocalDateTime.now();
+
+		if(!schedule.isInProgress(referenceTime)) {
+			throw new CertificateNotInSubmissionPeriodException();
 		}
 
 		String storedPath = fileStorageService.store(file, FileDomain.CERTIFICATE);

--- a/aics-domain/src/main/java/kgu/developers/domain/certificate/exception/CertificateDomainExceptionCode.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/certificate/exception/CertificateDomainExceptionCode.java
@@ -5,12 +5,16 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
 @AllArgsConstructor
 public enum CertificateDomainExceptionCode implements ExceptionCode {
-    CERTIFICATE_NOT_FOUND(NOT_FOUND, "해당 자격증을 찾을 수 없습니다.");
+    CERTIFICATE_NOT_FOUND(NOT_FOUND, "해당 자격증을 찾을 수 없습니다."),
+    CERTIFICATE_NOT_IN_SUBMISSION_PERIOD_EXCEPTION(BAD_REQUEST, "현재 자격증 제출 기간이 아닙니다."),
+    CERTIFICATE_INVALID_GRADUATION_TYPE_EXCEPTION(BAD_REQUEST, "선택하신 제출 방식이 자격증이 아닙니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/aics-domain/src/main/java/kgu/developers/domain/certificate/exception/CertificateInvalidGraduationTypeException.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/certificate/exception/CertificateInvalidGraduationTypeException.java
@@ -1,0 +1,11 @@
+package kgu.developers.domain.certificate.exception;
+
+import kgu.developers.common.exception.CustomException;
+
+import static kgu.developers.domain.certificate.exception.CertificateDomainExceptionCode.CERTIFICATE_INVALID_GRADUATION_TYPE_EXCEPTION;
+
+public class CertificateInvalidGraduationTypeException extends CustomException {
+    public CertificateInvalidGraduationTypeException() {
+        super(CERTIFICATE_INVALID_GRADUATION_TYPE_EXCEPTION);
+    }
+}

--- a/aics-domain/src/main/java/kgu/developers/domain/certificate/exception/CertificateNotInSubmissionPeriodException.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/certificate/exception/CertificateNotInSubmissionPeriodException.java
@@ -1,0 +1,11 @@
+package kgu.developers.domain.certificate.exception;
+
+import kgu.developers.common.exception.CustomException;
+
+import static kgu.developers.domain.certificate.exception.CertificateDomainExceptionCode.CERTIFICATE_NOT_IN_SUBMISSION_PERIOD_EXCEPTION;
+
+public class CertificateNotInSubmissionPeriodException extends CustomException {
+    public CertificateNotInSubmissionPeriodException() {
+        super(CERTIFICATE_NOT_IN_SUBMISSION_PERIOD_EXCEPTION);
+    }
+}

--- a/aics-domain/src/main/java/kgu/developers/domain/graduationUser/application/command/GraduationUserCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/graduationUser/application/command/GraduationUserCommandService.java
@@ -29,8 +29,6 @@ public class GraduationUserCommandService {
     }
 
     public void updateGraduationType(GraduationUser graduationUser, GraduationType type) {
-        graduationUser.validateAccessPermission(graduationUser.getUserId());
-
         graduationUser.updateGraduationType(type);
         graduationUserRepository.save(graduationUser);
     }
@@ -41,8 +39,6 @@ public class GraduationUserCommandService {
     }
 
     public void updateGraduationUserEmail(GraduationUser graduationUser, String email) {
-        graduationUser.validateAccessPermission(graduationUser.getUserId());
-
         graduationUser.updateEmail(email);
         graduationUserRepository.save(graduationUser);
     }

--- a/aics-domain/src/main/java/kgu/developers/domain/graduationUser/application/command/GraduationUserCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/graduationUser/application/command/GraduationUserCommandService.java
@@ -29,6 +29,8 @@ public class GraduationUserCommandService {
     }
 
     public void updateGraduationType(GraduationUser graduationUser, GraduationType type) {
+        graduationUser.validateAccessPermission(graduationUser.getUserId());
+
         graduationUser.updateGraduationType(type);
         graduationUserRepository.save(graduationUser);
     }
@@ -39,6 +41,8 @@ public class GraduationUserCommandService {
     }
 
     public void updateGraduationUserEmail(GraduationUser graduationUser, String email) {
+        graduationUser.validateAccessPermission(graduationUser.getUserId());
+
         graduationUser.updateEmail(email);
         graduationUserRepository.save(graduationUser);
     }

--- a/aics-domain/src/main/java/kgu/developers/domain/graduationUser/application/query/GraduationUserQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/graduationUser/application/query/GraduationUserQueryService.java
@@ -9,6 +9,7 @@ import kgu.developers.domain.graduationUser.domain.GraduationUserRepository;
 import kgu.developers.domain.graduationUser.exception.GraduationUserNotFoundException;
 import kgu.developers.domain.graduationUser.infrastructure.excel.GraduationUserExcelRow;
 import kgu.developers.domain.thesis.domain.ThesisRepository;
+import kgu.developers.domain.user.application.query.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GraduationUserQueryService {
+    private final UserQueryService userQueryService;
     private final GraduationUserRepository graduationUserRepository;
     private final ThesisRepository thesisRepository;
     private final CertificateRepository certificateRepository;
@@ -105,6 +107,12 @@ public class GraduationUserQueryService {
     }
 
     public GraduationUser getByUserId(String userId) {
+        return graduationUserRepository.findByUserIdAndDeletedAtIsNull(userId)
+            .orElseThrow(GraduationUserNotFoundException::new);
+    }
+
+    public GraduationUser me() {
+        String userId = userQueryService.getMyId();
         return graduationUserRepository.findByUserIdAndDeletedAtIsNull(userId)
             .orElseThrow(GraduationUserNotFoundException::new);
     }

--- a/aics-domain/src/main/java/kgu/developers/domain/schedule/application/query/ScheduleQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/schedule/application/query/ScheduleQueryService.java
@@ -40,10 +40,4 @@ public class ScheduleQueryService {
         return scheduleRepository.findBySubmissionType(submissionType)
                 .orElseThrow(ScheduleNotFoundException::new);
     }
-
-    public void checkExistsOrThrow(Long id) {
-        if (!scheduleRepository.existsById(id)) {
-            throw new ScheduleNotFoundException();
-        }
-    }
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/schedule/application/query/ScheduleQueryService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/schedule/application/query/ScheduleQueryService.java
@@ -24,6 +24,7 @@ public class ScheduleQueryService {
             APPROVED,
             OTHER
     );
+
     public List<Schedule> getAllScheduleManagements() {
 
         return scheduleRepository.findAll().stream()
@@ -36,6 +37,7 @@ public class ScheduleQueryService {
                 .findById(id)
                 .orElseThrow(ScheduleNotFoundException::new);
     }
+
     public Schedule getBySubmissionType(SubmissionType submissionType) {
         return scheduleRepository.findBySubmissionType(submissionType)
                 .orElseThrow(ScheduleNotFoundException::new);

--- a/aics-domain/src/main/java/kgu/developers/domain/schedule/domain/Schedule.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/schedule/domain/Schedule.java
@@ -41,6 +41,11 @@ public class Schedule {
         }
         return ScheduleStatus.IN_PROGRESS;
     }
+
+    public boolean isInProgress(LocalDateTime referenceTime) {
+        return determineStatusAt(referenceTime) == ScheduleStatus.IN_PROGRESS;
+    }
+
     public void updateSubmissionType(SubmissionType submissionType) {
         this.submissionType = submissionType;
     }

--- a/aics-domain/src/main/java/kgu/developers/domain/thesis/application/command/ThesisCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/thesis/application/command/ThesisCommandService.java
@@ -12,8 +12,8 @@ import kgu.developers.domain.schedule.domain.Schedule;
 import kgu.developers.domain.thesis.domain.Thesis;
 import kgu.developers.domain.thesis.domain.ThesisRepository;
 import kgu.developers.domain.thesis.exception.ThesisInvalidGraduationTypeException;
-import kgu.developers.domain.thesis.exception.ThesisNotInSubmissionPeriodException;
 import kgu.developers.domain.thesis.exception.ThesisNotFoundException;
+import kgu.developers.domain.thesis.exception.ThesisNotInSubmissionPeriodException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -34,14 +34,14 @@ public class ThesisCommandService {
 		Schedule schedule = scheduleQueryService.getScheduleManagement(scheduleId);
 		LocalDateTime referenceTime = LocalDateTime.now();
 
-		if(!schedule.isInProgress(referenceTime)) {
-			throw new ThesisNotInSubmissionPeriodException();
-		}
-
 		GraduationUser graduationUser = graduationUserQueryService.me();
 
 		if(graduationUser.getGraduationType() != GraduationType.THESIS) {
 			throw new ThesisInvalidGraduationTypeException();
+		}
+
+		if(!schedule.isInProgress(referenceTime)) {
+			throw new ThesisNotInSubmissionPeriodException();
 		}
 
 		String storedPath = fileStorageService.store(file, FileDomain.THESIS);

--- a/aics-domain/src/main/java/kgu/developers/domain/thesis/application/command/ThesisCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/thesis/application/command/ThesisCommandService.java
@@ -4,13 +4,21 @@ import jakarta.transaction.Transactional;
 import kgu.developers.domain.file.application.command.FileCommandService;
 import kgu.developers.domain.file.domain.FileDomain;
 import kgu.developers.domain.file.infrastructure.repository.FileStorageService;
+import kgu.developers.domain.graduationUser.application.query.GraduationUserQueryService;
+import kgu.developers.domain.graduationUser.domain.GraduationType;
+import kgu.developers.domain.graduationUser.domain.GraduationUser;
 import kgu.developers.domain.schedule.application.query.ScheduleQueryService;
+import kgu.developers.domain.schedule.domain.Schedule;
 import kgu.developers.domain.thesis.domain.Thesis;
 import kgu.developers.domain.thesis.domain.ThesisRepository;
+import kgu.developers.domain.thesis.exception.ThesisInvalidGraduationTypeException;
+import kgu.developers.domain.thesis.exception.ThesisNotInSubmissionPeriodException;
 import kgu.developers.domain.thesis.exception.ThesisNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
 
 @Service
 @Transactional
@@ -20,11 +28,24 @@ public class ThesisCommandService {
 	private final FileStorageService fileStorageService;
 	private final FileCommandService fileCommandService;
 	private final ScheduleQueryService scheduleQueryService;
+	private final GraduationUserQueryService graduationUserQueryService;
 
 	public Long submitThesis(MultipartFile file, Long scheduleId) {
+		Schedule schedule = scheduleQueryService.getScheduleManagement(scheduleId);
+		LocalDateTime referenceTime = LocalDateTime.now();
+
+		if(!schedule.isInProgress(referenceTime)) {
+			throw new ThesisNotInSubmissionPeriodException();
+		}
+
+		GraduationUser graduationUser = graduationUserQueryService.me();
+
+		if(graduationUser.getGraduationType() != GraduationType.THESIS) {
+			throw new ThesisInvalidGraduationTypeException();
+		}
+
 		String storedPath = fileStorageService.store(file, FileDomain.THESIS);
 		Long fileId = fileCommandService.saveFile(file, storedPath).getId();
-		scheduleQueryService.checkExistsOrThrow(scheduleId);
 
 		Thesis thesis = Thesis.create(scheduleId, fileId);
 		return thesisRepository.save(thesis);

--- a/aics-domain/src/main/java/kgu/developers/domain/thesis/exception/ThesisDomainExceptionCode.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/thesis/exception/ThesisDomainExceptionCode.java
@@ -5,12 +5,15 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Getter
 @AllArgsConstructor
 public enum ThesisDomainExceptionCode implements ExceptionCode {
-    THESIS_NOT_FOUND(NOT_FOUND, "해당 논문을 찾을 수 없습니다.");
+    THESIS_NOT_FOUND(BAD_REQUEST, "해당 논문을 찾을 수 없습니다."),
+    THESIS_NOT_IN_SUBMISSION_PERIOD_EXCEPTION(BAD_REQUEST, "현재 논문 제출 기간이 아닙니다."),
+    THESIS_INVALID_GRADUATION_TYPE_EXCEPTION(BAD_REQUEST, "선택하신 제출 방식이 논문이 아닙니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/aics-domain/src/main/java/kgu/developers/domain/thesis/exception/ThesisInvalidGraduationTypeException.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/thesis/exception/ThesisInvalidGraduationTypeException.java
@@ -1,0 +1,11 @@
+package kgu.developers.domain.thesis.exception;
+
+import kgu.developers.common.exception.CustomException;
+
+import static kgu.developers.domain.thesis.exception.ThesisDomainExceptionCode.THESIS_INVALID_GRADUATION_TYPE_EXCEPTION;
+
+public class ThesisInvalidGraduationTypeException extends CustomException {
+    public ThesisInvalidGraduationTypeException() {
+        super(THESIS_INVALID_GRADUATION_TYPE_EXCEPTION);
+    }
+}

--- a/aics-domain/src/main/java/kgu/developers/domain/thesis/exception/ThesisNotInSubmissionPeriodException.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/thesis/exception/ThesisNotInSubmissionPeriodException.java
@@ -1,0 +1,11 @@
+package kgu.developers.domain.thesis.exception;
+
+import kgu.developers.common.exception.CustomException;
+
+import static kgu.developers.domain.thesis.exception.ThesisDomainExceptionCode.THESIS_NOT_IN_SUBMISSION_PERIOD_EXCEPTION;
+
+public class ThesisNotInSubmissionPeriodException extends CustomException {
+    public ThesisNotInSubmissionPeriodException() {
+        super(THESIS_NOT_IN_SUBMISSION_PERIOD_EXCEPTION);
+    }
+}

--- a/aics-domain/src/testFixtures/java/graduationUser/application/GraduationUserCommandServiceTest.java
+++ b/aics-domain/src/testFixtures/java/graduationUser/application/GraduationUserCommandServiceTest.java
@@ -134,20 +134,28 @@ public class GraduationUserCommandServiceTest {
     }
 
     @Test
-    @DisplayName("updateMidThesis은 주어진 타입에 따라 GraduationUser의 논문ID를 저장한다.")
+    @DisplayName("updateThesis은 주어진 타입에 따라 GraduationUser의 논문ID를 저장한다.")
     public void updateThesis_Success() {
         //given
-        Long thesisId = 1L;
-        Schedule schedule = Schedule.builder()
+        Long midThesisId = 1L;
+        Long finalThesisId = 2L;
+        Schedule midSchedule = Schedule.builder()
+            .id(1L)
+            .submissionType(SubmissionType.MIDTHESIS)
+            .build();
+
+        Schedule finalSchedule = Schedule.builder()
             .id(1L)
             .submissionType(SubmissionType.FINALTHESIS)
             .build();
 
         //when
-        graduationUserCommandService.updateThesis(graduationUser, thesisId, schedule);
+        graduationUserCommandService.updateThesis(graduationUser, midThesisId, midSchedule);
+        graduationUserCommandService.updateThesis(graduationUser, finalThesisId, finalSchedule);
 
         //then
-        assertEquals(graduationUser.getFinalThesisId(),thesisId);
+        assertEquals(graduationUser.getMidThesisId(), midThesisId);
+        assertEquals(graduationUser.getFinalThesisId(), finalThesisId);
     }
 
 }

--- a/aics-domain/src/testFixtures/java/graduationUser/application/GraduationUserQueryServiceTest.java
+++ b/aics-domain/src/testFixtures/java/graduationUser/application/GraduationUserQueryServiceTest.java
@@ -3,11 +3,12 @@ package graduationUser.application;
 import kgu.developers.common.response.PaginatedListResponse;
 import kgu.developers.domain.graduationUser.application.query.GraduationUserQueryService;
 import kgu.developers.domain.graduationUser.domain.GraduationUser;
-import kgu.developers.domain.graduationUser.domain.GraduationUserExcel;
 import kgu.developers.domain.graduationUser.infrastructure.excel.GraduationUserExcelImpl;
+import kgu.developers.domain.user.application.query.UserQueryService;
 import mock.repository.FakeCertificateRepository;
 import mock.repository.FakeGraduationUserRepository;
 import mock.repository.FakeThesisRepository;
+import mock.repository.FakeUserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,11 +27,14 @@ public class GraduationUserQueryServiceTest {
     public void init() {
         FakeGraduationUserRepository fakeGraduationUserRepository = new FakeGraduationUserRepository();
 
+        UserQueryService userQueryService = new UserQueryService(new FakeUserRepository());
+
         graduationUserQueryService = new GraduationUserQueryService(
-                fakeGraduationUserRepository,
-                new FakeThesisRepository(),
-                new FakeCertificateRepository(),
-                new GraduationUserExcelImpl());
+            userQueryService,
+            fakeGraduationUserRepository,
+            new FakeThesisRepository(),
+            new FakeCertificateRepository(),
+            new GraduationUserExcelImpl());
 
         fakeGraduationUserRepository.save(GraduationUser.create(
             "202211444", "홍길동", "김교수", true, "컴퓨터공학과", LocalDate.of(2024, 2, 20)

--- a/aics-domain/src/testFixtures/java/graduationUser/application/GraduationUserQueryServiceTest.java
+++ b/aics-domain/src/testFixtures/java/graduationUser/application/GraduationUserQueryServiceTest.java
@@ -2,9 +2,11 @@ package graduationUser.application;
 
 import kgu.developers.common.response.PaginatedListResponse;
 import kgu.developers.domain.graduationUser.application.query.GraduationUserQueryService;
+import kgu.developers.domain.graduationUser.domain.GraduationType;
 import kgu.developers.domain.graduationUser.domain.GraduationUser;
 import kgu.developers.domain.graduationUser.infrastructure.excel.GraduationUserExcelImpl;
 import kgu.developers.domain.user.application.query.UserQueryService;
+import kgu.developers.domain.user.domain.User;
 import mock.repository.FakeCertificateRepository;
 import mock.repository.FakeGraduationUserRepository;
 import mock.repository.FakeThesisRepository;
@@ -13,21 +15,26 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDate;
 
+import static kgu.developers.domain.user.domain.Major.CSE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GraduationUserQueryServiceTest {
     private GraduationUserQueryService graduationUserQueryService;
     private static final Long TARGET_GRADUATION_USER_ID = 1L;
     private static final String TARGET_STUDENT_ID = "202211444";
-
+    FakeGraduationUserRepository fakeGraduationUserRepository;
     @BeforeEach
     public void init() {
-        FakeGraduationUserRepository fakeGraduationUserRepository = new FakeGraduationUserRepository();
-
-        UserQueryService userQueryService = new UserQueryService(new FakeUserRepository());
+        fakeGraduationUserRepository = new FakeGraduationUserRepository();
+        FakeUserRepository fakeUserRepository = new FakeUserRepository();
+        UserQueryService userQueryService = new UserQueryService(fakeUserRepository);
 
         graduationUserQueryService = new GraduationUserQueryService(
             userQueryService,
@@ -55,6 +62,21 @@ public class GraduationUserQueryServiceTest {
         fakeGraduationUserRepository.save(GraduationUser.create(
             "202214567", "정수진", "이교수", false, "인공지능학과", LocalDate.of(2024, 2, 20)
         ));
+
+        fakeUserRepository.save(User.builder()
+            .id("202211444")
+            .password("password1234")
+            .name("홍길동")
+            .email("test1@kyonggi.ac.kr")
+            .phone("010-1234-5679")
+            .major(CSE)
+            .build());
+
+        UserDetails user = userQueryService.getUserById("202211444");
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, user.getPassword(), user.getAuthorities())
+        );
     }
 
     @Test
@@ -97,6 +119,35 @@ public class GraduationUserQueryServiceTest {
         //then
         assertEquals(TARGET_GRADUATION_USER_ID, graduationUser.getId());
         assertEquals(TARGET_STUDENT_ID, graduationUser.getUserId());
+
+    }
+
+    @Test
+    @DisplayName("getGraduationTypeByUserId는 해당 학번의 졸업 대상자의 졸업 방식을 반환한다.")
+    public void getGraduationTypeByUserId_Success() {
+        //given
+        GraduationUser graduationUser = fakeGraduationUserRepository.findByUserIdAndDeletedAtIsNull(TARGET_STUDENT_ID).orElse(null);
+        graduationUser.updateGraduationType(GraduationType.THESIS);
+        fakeGraduationUserRepository.save(graduationUser);
+
+        //when
+        GraduationType graduationType = graduationUserQueryService.getGraduationTypeByUserId(TARGET_STUDENT_ID);
+
+        //then
+        assertEquals(GraduationType.THESIS, graduationType);
+
+    }
+
+    @Test
+    @DisplayName("me는 현재 로그인 되어 있는 졸업 대상자를 조회한다.")
+    public void Success() {
+        //given
+
+        //when
+        GraduationUser result = graduationUserQueryService.me();
+
+        //then
+        assertEquals(TARGET_GRADUATION_USER_ID, result.getId());
 
     }
 }

--- a/aics-domain/src/testFixtures/java/schedule/application/ScheduleQueryServiceTest.java
+++ b/aics-domain/src/testFixtures/java/schedule/application/ScheduleQueryServiceTest.java
@@ -9,11 +9,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ScheduleQueryServiceTest {
     private ScheduleQueryService scheduleQueryService;
@@ -64,11 +64,21 @@ public class ScheduleQueryServiceTest {
     }
 
     @Test
-    @DisplayName("getScheduleManagement는 존재하지 않는 ID면 예외를 던집니다.")
+    @DisplayName("getScheduleManagement는 존재하지 않는 ID면 예외를 던진다.")
     void getScheduleManagement_NotFound() {
         assertThrows(ScheduleNotFoundException.class, () -> scheduleQueryService.getScheduleManagement(99L));
     }
 
+    @Test
+    @DisplayName("getBySubmissionType은 제출 방식을 가지고 일정을 조회한다.")
+    public void Success() {
+        //given
 
+        //when
+        Schedule schedule = scheduleQueryService.getBySubmissionType(SubmissionType.SUBMITTED);
+
+        //then
+        assertEquals(SubmissionType.SUBMITTED, schedule.getSubmissionType());
+    }
 
 }


### PR DESCRIPTION
## Summary

>- #314 

논문/자격증 제출 시 제출자의 졸업 방식과 일정의 진행 여부를 토대로 유효성을 검증합니다.

## Tasks

- GraduationUser를 UserQueryService를 직접 거치지 않고 얻어올 수 있도록 리팩토링
- 제출자의 졸업 방식을 조회하여 제출한 파일인지 검사
- 제출한 일정을 조회하여 현재 진행중인 일정인지 검사
