### PR TITLE
feature/KD-73: 자격증 신청 관리 메뉴와 졸업 논문 관리 메뉴에서 승인된 사용자 승인 취소 기능 추가

### DIFF
--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/application/GraduationUserAdminFacade.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/application/GraduationUserAdminFacade.java
@@ -4,10 +4,12 @@ import kgu.developers.admin.graduationUser.presentation.dto.GraduationUserExcelF
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchApproveRequest;
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchCreateRequest;
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchDeleteRequest;
+import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchDisapproveRequest;
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserCreateRequest;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserBatchApproveResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserBatchCreateResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserBatchDeleteResponse;
+import kgu.developers.admin.graduationUser.presentation.response.GraduationUserBatchDisapproveResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserDetailResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserPersistResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserStatusResponse;
@@ -189,5 +191,37 @@ public class GraduationUserAdminFacade {
         }
 
         return GraduationUserBatchApproveResponse.from(approvedUserIds);
+    }
+
+    public GraduationUserBatchDisapproveResponse disapproveGraduationUsers(GraduationUserBatchDisapproveRequest request) {
+        List<GraduationUser> users = request.ids().stream()
+                .map(graduationUserQueryService::getById)
+                .toList();
+
+        List<Long> disapprovedUserIds = new ArrayList<>();
+
+        for(GraduationUser user: users) {
+            if(user.getGraduationType() == GraduationType.CERTIFICATE) {
+                if(user.getCertificateId() == null) continue;
+                boolean disapproved = certificateCommandService.disapprove(user.getCertificateId());
+                if(disapproved) disapprovedUserIds.add(user.getId());
+            } else if(user.getGraduationType() == GraduationType.THESIS) {
+                boolean midThesisdisapproved = false;
+                boolean finalThesisdisapproved = false;
+
+                if(user.getMidThesisId() != null) {
+                    midThesisdisapproved = thesisCommandService.disapprove(user.getMidThesisId());
+                }
+
+                if(user.getFinalThesisId() != null) {
+                    finalThesisdisapproved = thesisCommandService.disapprove(user.getFinalThesisId());
+                }
+
+                if(midThesisdisapproved || finalThesisdisapproved)
+                    disapprovedUserIds.add(user.getId());
+            }
+        }
+
+        return GraduationUserBatchDisapproveResponse.from(disapprovedUserIds);
     }
 }

--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/GraduationUserAdminController.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/GraduationUserAdminController.java
@@ -12,10 +12,12 @@ import jakarta.validation.constraints.PositiveOrZero;
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchApproveRequest;
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchCreateRequest;
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchDeleteRequest;
+import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchDisapproveRequest;
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserCreateRequest;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserBatchApproveResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserBatchCreateResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserBatchDeleteResponse;
+import kgu.developers.admin.graduationUser.presentation.response.GraduationUserBatchDisapproveResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserDetailResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserPersistResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserSummaryPageResponse;
@@ -147,5 +149,17 @@ public interface GraduationUserAdminController {
                     description = "승인할 졸업 대상자 ID 목록",
                     required = true
             ) @Valid @RequestBody GraduationUserBatchApproveRequest request
+    );
+
+    @Operation(summary = "졸업 대상자 일괄 승인 취소 API", description = """
+			- Description : 이 API는 선택한 여러 졸업 대상자의 제출을 일괄 승인 취소합니다.
+			- Assignee : 장영후
+		""")
+    @ApiResponse(responseCode = "200")
+    ResponseEntity<GraduationUserBatchDisapproveResponse> disapproveGraduationUsers(
+            @Parameter(
+                    description = "승인 취소할 졸업 대상자 ID 목록",
+                    required = true
+            ) @Valid @RequestBody GraduationUserBatchDisapproveRequest request
     );
 }

--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/GraduationUserAdminController.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/GraduationUserAdminController.java
@@ -153,7 +153,7 @@ public interface GraduationUserAdminController {
 
     @Operation(summary = "졸업 대상자 일괄 승인 취소 API", description = """
 			- Description : 이 API는 선택한 여러 졸업 대상자의 제출을 일괄 승인 취소합니다.
-			- Assignee : 장영후
+			- Assignee : 황호찬
 		""")
     @ApiResponse(responseCode = "200")
     ResponseEntity<GraduationUserBatchDisapproveResponse> disapproveGraduationUsers(

--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/GraduationUserAdminControllerImpl.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/GraduationUserAdminControllerImpl.java
@@ -8,10 +8,12 @@ import kgu.developers.admin.graduationUser.presentation.dto.GraduationUserExcelF
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchApproveRequest;
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchCreateRequest;
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchDeleteRequest;
+import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchDisapproveRequest;
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserCreateRequest;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserBatchApproveResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserBatchCreateResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserBatchDeleteResponse;
+import kgu.developers.admin.graduationUser.presentation.response.GraduationUserBatchDisapproveResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserDetailResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserPersistResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserSummaryPageResponse;
@@ -122,6 +124,15 @@ public class GraduationUserAdminControllerImpl implements GraduationUserAdminCon
             @Valid @RequestBody GraduationUserBatchApproveRequest request
     ) {
         GraduationUserBatchApproveResponse response = graduationUserAdminFacade.approveGraduationUsers(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @PatchMapping("/batch/disapprove")
+    public ResponseEntity<GraduationUserBatchDisapproveResponse> disapproveGraduationUsers(
+            @Valid @RequestBody GraduationUserBatchDisapproveRequest request
+    ) {
+        GraduationUserBatchDisapproveResponse response = graduationUserAdminFacade.disapproveGraduationUsers(request);
         return ResponseEntity.ok(response);
     }
 }

--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/request/GraduationUserBatchDisapproveRequest.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/request/GraduationUserBatchDisapproveRequest.java
@@ -1,0 +1,16 @@
+package kgu.developers.admin.graduationUser.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Positive;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GraduationUserBatchDisapproveRequest(
+        @Schema(description = "승인 취소할 졸업 대상자 ID 목록", example = "[1, 2, 3]")
+        @NotEmpty(message = "승인 취소할 대상자를 선택해주세요.")
+        List<@Positive(message = "잘못된 ID 형식입니다.") Long> ids
+) {
+}

--- a/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserBatchDisapproveResponse.java
+++ b/aics-admin/src/main/java/kgu/developers/admin/graduationUser/presentation/response/GraduationUserBatchDisapproveResponse.java
@@ -1,0 +1,20 @@
+package kgu.developers.admin.graduationUser.presentation.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+@Builder
+public record GraduationUserBatchDisapproveResponse(
+        @Schema(description = "승인 취소 처리된 졸업 대상자 ID 목록", example = "[1, 2, 3, 4, 5]", requiredMode = REQUIRED)
+        List<Long> disapprovedIds
+) {
+    public static GraduationUserBatchDisapproveResponse from(List<Long> disapprovedUserIds) {
+            return GraduationUserBatchDisapproveResponse.builder()
+                    .disapprovedIds(disapprovedUserIds)
+                    .build();
+    }
+}

--- a/aics-admin/src/testFixtures/java/graduationUser/application/GraduationUserAdminFacadeTest.java
+++ b/aics-admin/src/testFixtures/java/graduationUser/application/GraduationUserAdminFacadeTest.java
@@ -320,9 +320,9 @@ public class GraduationUserAdminFacadeTest {
     public void disapproveGraduationUsers_Success() {
         // given
         // 먼저 승인된 상태로 만듦
+        fakeCertificateRepository.save(Certificate.of(1L, 1L, 1L, true, null, null, null));
         fakeThesisRepository.save(Thesis.of(1L, 1L, 1L, true, null, null, null));
         fakeThesisRepository.save(Thesis.of(2L, 1L, 2L, true, null, null, null));
-        fakeCertificateRepository.save(Certificate.of(1L, 1L, 1L, true, null, null, null));
 
         List<Long> graduationUserIds = Arrays.asList(1L, 2L);
         GraduationUserBatchDisapproveRequest request = GraduationUserBatchDisapproveRequest.builder()
@@ -330,12 +330,49 @@ public class GraduationUserAdminFacadeTest {
                 .build();
 
         // when
-        graduationUserAdminFacade.disapproveGraduationUsers(request);
+        GraduationUserBatchDisapproveResponse response = graduationUserAdminFacade.disapproveGraduationUsers(request);
 
         // then
+        assertEquals(2, response.disapprovedIds().size());
+        assertEquals(false, fakeCertificateRepository.findApprovalByIdAndDeletedAtIsNull(1L).get());
         assertEquals(false, fakeThesisRepository.findApprovalByIdAndDeletedAtIsNull(1L).get());
         assertEquals(false, fakeThesisRepository.findApprovalByIdAndDeletedAtIsNull(2L).get());
+    }
+
+    @Test
+    @DisplayName("disapproveGraduationUsers는 이미 승인이 취소된 유저는 결과 목록에 포함하지 않는다.")
+    public void disapproveGraduationUsers_AlreadyDisapproved() {
+        // given
+        // 이미 승인 취소 상태로 만듦
+        fakeCertificateRepository.save(Certificate.of(1L, 1L, 1L, false, null, null, null));
+
+        List<Long> graduationUserIds = List.of(1L);
+        GraduationUserBatchDisapproveRequest request = GraduationUserBatchDisapproveRequest.builder()
+                .ids(graduationUserIds)
+                .build();
+
+        // when
+        GraduationUserBatchDisapproveResponse response = graduationUserAdminFacade.disapproveGraduationUsers(request);
+
+        // then
+        assertEquals(0, response.disapprovedIds().size());
         assertEquals(false, fakeCertificateRepository.findApprovalByIdAndDeletedAtIsNull(1L).get());
     }
 
+    @Test
+    @DisplayName("disapproveGraduationUsers는 제출물이 없는 유저는 무시한다.")
+    public void disapproveGraduationUsers_NoSubmission() {
+        // given
+        // graduationUser3은 자격증이나 논문 ID가 없는 상태
+        List<Long> graduationUserIds = List.of(3L);
+        GraduationUserBatchDisapproveRequest request = GraduationUserBatchDisapproveRequest.builder()
+                .ids(graduationUserIds)
+                .build();
+
+        // when
+        GraduationUserBatchDisapproveResponse response = graduationUserAdminFacade.disapproveGraduationUsers(request);
+
+        // then
+        assertEquals(0, response.disapprovedIds().size());
+    }
 }

--- a/aics-admin/src/testFixtures/java/graduationUser/application/GraduationUserAdminFacadeTest.java
+++ b/aics-admin/src/testFixtures/java/graduationUser/application/GraduationUserAdminFacadeTest.java
@@ -4,8 +4,10 @@ import kgu.developers.admin.graduationUser.application.GraduationUserAdminFacade
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchApproveRequest;
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchCreateRequest;
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchDeleteRequest;
+import kgu.developers.admin.graduationUser.presentation.request.GraduationUserBatchDisapproveRequest;
 import kgu.developers.admin.graduationUser.presentation.request.GraduationUserCreateRequest;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserBatchCreateResponse;
+import kgu.developers.admin.graduationUser.presentation.response.GraduationUserBatchDisapproveResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserDetailResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserPersistResponse;
 import kgu.developers.admin.graduationUser.presentation.response.GraduationUserSummaryPageResponse;
@@ -311,6 +313,29 @@ public class GraduationUserAdminFacadeTest {
         assertEquals(true,fakeThesisRepository.findApprovalByIdAndDeletedAtIsNull(1L).get());
         assertEquals(true,fakeThesisRepository.findApprovalByIdAndDeletedAtIsNull(2L).get());
         assertEquals(true,fakeCertificateRepository.findApprovalByIdAndDeletedAtIsNull(1L).get());
+    }
+
+    @Test
+    @DisplayName("disapproveGraduationUsers는 여러 GraduationUser의 제출 승인을 취소한다.")
+    public void disapproveGraduationUsers_Success() {
+        // given
+        // 먼저 승인된 상태로 만듦
+        fakeThesisRepository.save(Thesis.of(1L, 1L, 1L, true, null, null, null));
+        fakeThesisRepository.save(Thesis.of(2L, 1L, 2L, true, null, null, null));
+        fakeCertificateRepository.save(Certificate.of(1L, 1L, 1L, true, null, null, null));
+
+        List<Long> graduationUserIds = Arrays.asList(1L, 2L);
+        GraduationUserBatchDisapproveRequest request = GraduationUserBatchDisapproveRequest.builder()
+                .ids(graduationUserIds)
+                .build();
+
+        // when
+        graduationUserAdminFacade.disapproveGraduationUsers(request);
+
+        // then
+        assertEquals(false, fakeThesisRepository.findApprovalByIdAndDeletedAtIsNull(1L).get());
+        assertEquals(false, fakeThesisRepository.findApprovalByIdAndDeletedAtIsNull(2L).get());
+        assertEquals(false, fakeCertificateRepository.findApprovalByIdAndDeletedAtIsNull(1L).get());
     }
 
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/certificate/application/command/CertificateCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/certificate/application/command/CertificateCommandService.java
@@ -62,4 +62,14 @@ public class CertificateCommandService {
 		certificateRepository.save(certificate);
 		return true;
     }
+
+	public boolean disapprove(Long certificateId) {
+		Certificate certificate = certificateRepository.findByIdAndDeletedAtIsNull(certificateId)
+				.orElseThrow(CertificateNotFoundException::new);
+
+		if (!certificate.isApproved()) return false;
+		certificate.disapprove();
+		certificateRepository.save(certificate);
+		return true;
+	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/certificate/domain/Certificate.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/certificate/domain/Certificate.java
@@ -58,4 +58,8 @@ public class Certificate {
 	public void approve() {
 		this.approval = true;
 	}
+
+	public void disapprove() {
+		this.approval = false;
+	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/thesis/application/command/ThesisCommandService.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/thesis/application/command/ThesisCommandService.java
@@ -67,4 +67,14 @@ public class ThesisCommandService {
 		thesisRepository.save(thesis);
 		return true;
     }
+
+	public boolean disapprove(Long thesisId) {
+		Thesis thesis = thesisRepository.findByIdAndDeletedAtIsNull(thesisId)
+				.orElseThrow(ThesisNotFoundException::new);
+
+		if (!thesis.isApproved()) return false;
+		thesis.disapprove();
+		thesisRepository.save(thesis);
+		return true;
+	}
 }

--- a/aics-domain/src/main/java/kgu/developers/domain/thesis/domain/Thesis.java
+++ b/aics-domain/src/main/java/kgu/developers/domain/thesis/domain/Thesis.java
@@ -55,4 +55,8 @@ public class Thesis {
 	public void approve() {
 		this.approval = true;
 	}
+
+	public void disapprove() {
+		this.approval = false;
+	}
 }

--- a/aics-domain/src/testFixtures/java/mock/repository/FakeCertificateRepository.java
+++ b/aics-domain/src/testFixtures/java/mock/repository/FakeCertificateRepository.java
@@ -46,4 +46,6 @@ public class FakeCertificateRepository implements CertificateRepository {
             .findFirst()
             .map(Certificate::isApproved);
     }
+
+
 }


### PR DESCRIPTION
 Summary

>- #331 

자격증 신청 관리 메뉴와 졸업 논문 관리 메뉴에서 승인된 사용자 승인 취소 기능을 추가했습니다.

## Tasks

-  Certificate, Thesis 도메인 엔티티 내 승인 취소(disapprove) 메서드 추가
- CertificateCommandService, ThesisCommandService 내 승인 취소 비즈니스 로직 구현
- GraduationUserBatchDisapproveRequest/Response DTO 생성 및 Swagger 스키마 정의
- GraduationUserAdminFacade 내 일괄 승인 취소 비즈니스 로직 추가
- GraduationUserAdminController 내 일괄 승인 취소 API(/batch/disapprove)구현
- GraduationUserAdminFacadeTest 내 일괄 승인 취소 기능 검증 테스트 코드 추가